### PR TITLE
🪲 [Fix]: Avoid using Set-ModuleManifest on diverse runners

### DIFF
--- a/scripts/helpers/Test-PSModule.ps1
+++ b/scripts/helpers/Test-PSModule.ps1
@@ -127,7 +127,7 @@ function Test-PSModule {
     if ((Test-Path -Path $moduleTestsPath) -and $testModule) {
         Start-LogGroup "Importing module: $moduleName"
         $moduleManifestPath = Join-Path -Path $Path -ChildPath "$moduleName.psd1"
-        Set-ModuleManifest -Path $moduleManifestPath -ModuleVersion '999.0.0'
+        #TODO: Fix in Utiltities first: Set-ModuleManifest -Path $moduleManifestPath -ModuleVersion '999.0.0'
         Add-PSModulePath -Path (Split-Path $Path -Parent)
         Get-Module -Name $moduleName -ListAvailable | Remove-Module -Force
         Import-Module -Name $moduleName -Force -RequiredVersion '999.0.0' -Global

--- a/scripts/helpers/Test-PSModule.ps1
+++ b/scripts/helpers/Test-PSModule.ps1
@@ -126,8 +126,6 @@ function Test-PSModule {
     #region Import module
     if ((Test-Path -Path $moduleTestsPath) -and $testModule) {
         Start-LogGroup "Importing module: $moduleName"
-        $moduleManifestPath = Join-Path -Path $Path -ChildPath "$moduleName.psd1"
-        #TODO: Fix in Utiltities first: Set-ModuleManifest -Path $moduleManifestPath -ModuleVersion '999.0.0'
         Add-PSModulePath -Path (Split-Path $Path -Parent)
         Get-Module -Name $moduleName -ListAvailable | Remove-Module -Force
         Import-Module -Name $moduleName -Force -RequiredVersion '999.0.0' -Global

--- a/tests/outputs/modules/PSModuleTest/PSModuleTest.psd1
+++ b/tests/outputs/modules/PSModuleTest/PSModuleTest.psd1
@@ -1,6 +1,6 @@
 ﻿@{
     RootModule            = 'PSModuleTest.psm1'
-    ModuleVersion         = '0.0.1'
+    ModuleVersion         = '999.0.0'
     CompatiblePSEditions  = @(
         'Core'
         'Desktop'


### PR DESCRIPTION
## Description

- Stop using Set-ModuleManifest as it is not compatible with Windows PowerShell yet. This needs a fix in Utilities first.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
