### PR TITLE
🚀 [Feature]: Add `passed` output and continue if fails

### DIFF
--- a/.github/linters/.powershell-psscriptanalyzer.psd1
+++ b/.github/linters/.powershell-psscriptanalyzer.psd1
@@ -1,0 +1,17 @@
+﻿#Documentation: https://github.com/PowerShell/PSScriptAnalyzer/blob/master/docs/Cmdlets/Invoke-ScriptAnalyzer.md#-settings
+@{
+    #CustomRulePath='path\to\CustomRuleModule.psm1'
+    #RecurseCustomRulePath='path\of\customrules'
+    #Severity = @(
+    #    'Error'
+    #    'Warning'
+    #)
+    #IncludeDefaultRules=${true}
+    ExcludeRules = @(
+        'PSAvoidUsingWriteHost'
+    )
+    #IncludeRules = @(
+    #    'PSAvoidUsingWriteHost',
+    #    'MyCustomRuleName'
+    #)
+}

--- a/action.yml
+++ b/action.yml
@@ -39,7 +39,9 @@ runs:
         # Test-PSModule
         $passed = . "$env:GITHUB_ACTION_PATH\scripts\main.ps1" -Verbose
         Write-Host "passed=$passed" >> $GITHUB_OUTPUT
-        exit $passed
+        if (-not $passed) {
+          exit 1
+        }
 
     - name: Upload test results
       uses: actions/upload-artifact@v4

--- a/action.yml
+++ b/action.yml
@@ -38,7 +38,7 @@ runs:
       run: |
         # Test-PSModule
         $passed = . "$env:GITHUB_ACTION_PATH\scripts\main.ps1" -Verbose
-        Write-Host "passed=$passed" >> $GITHUB_OUTPUT
+        "passed=$passed" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
         if (-not $passed) {
           exit 1
         }

--- a/action.yml
+++ b/action.yml
@@ -37,8 +37,14 @@ runs:
         GITHUB_ACTION_INPUT_TestType: ${{ inputs.TestType }}
       run: |
         # Test-PSModule
-        $passed = . "$env:GITHUB_ACTION_PATH\scripts\main.ps1" -Verbose
-        "passed=$passed" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        try {
+            $passed = . "$env:GITHUB_ACTION_PATH\scripts\main.ps1" -Verbose
+            "passed=$passed" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+        } catch {
+            Write-Error $_
+            exit 1
+        }
+
         if (-not $passed) {
           exit 1
         }

--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,7 @@ runs:
         # Test-PSModule
         $passed = . "$env:GITHUB_ACTION_PATH\scripts\main.ps1" -Verbose
         Write-Host "passed=$passed" >> $GITHUB_OUTPUT
+        exit $passed
 
     - name: Upload test results
       uses: actions/upload-artifact@v4

--- a/action.yml
+++ b/action.yml
@@ -20,10 +20,16 @@ inputs:
     required: false
     default: pwsh
 
+outputs:
+  passed:
+    description: If the tests passed.
+    value: ${{ steps.test.outputs.passed }}
+
 runs:
   using: composite
   steps:
     - name: Run Test-PSModule
+      id: test
       shell: ${{ inputs.Shell }}
       env:
         GITHUB_ACTION_INPUT_Name: ${{ inputs.Name }}
@@ -31,7 +37,8 @@ runs:
         GITHUB_ACTION_INPUT_TestType: ${{ inputs.TestType }}
       run: |
         # Test-PSModule
-        . "$env:GITHUB_ACTION_PATH\scripts\main.ps1" -Verbose
+        $passed = . "$env:GITHUB_ACTION_PATH\scripts\main.ps1" -Verbose
+        Write-Host "passed=$passed" >> $GITHUB_OUTPUT
 
     - name: Upload test results
       uses: actions/upload-artifact@v4

--- a/action.yml
+++ b/action.yml
@@ -37,13 +37,8 @@ runs:
         GITHUB_ACTION_INPUT_TestType: ${{ inputs.TestType }}
       run: |
         # Test-PSModule
-        try {
-            $passed = . "$env:GITHUB_ACTION_PATH\scripts\main.ps1" -Verbose
-            "passed=$passed" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
-        } catch {
-            Write-Error $_
-            exit 1
-        }
+        $passed = . "$env:GITHUB_ACTION_PATH\scripts\main.ps1" -Verbose
+        "passed=$passed" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
         if (-not $passed) {
           exit 1
@@ -51,14 +46,14 @@ runs:
 
     - name: Upload test results
       uses: actions/upload-artifact@v4
-      if: ${{ inputs.TestType == 'Module' }}
+      if: ${{ inputs.TestType == 'Module' && (success() || failure()) }}
       with:
         name: ${{ runner.os }}-${{ inputs.Shell }}-Test-Report
         path: ${{ github.workspace }}/outputs/Test-Report.xml
 
     - name: Upload code coverage report
       uses: actions/upload-artifact@v4
-      if: ${{ inputs.TestType == 'Module' }}
+      if: ${{ inputs.TestType == 'Module' && (success() || failure()) }}
       with:
         name: ${{ runner.os }}-${{ inputs.Shell }}-CodeCoverage-Report
         path: ${{ github.workspace }}/outputs/CodeCoverage-Report.xml

--- a/scripts/helpers/Resolve-PSModuleDependency.ps1
+++ b/scripts/helpers/Resolve-PSModuleDependency.ps1
@@ -1,0 +1,60 @@
+﻿function Resolve-PSModuleDependency {
+    <#
+        .SYNOPSIS
+        Resolve dependencies for a module based on the manifest file.
+
+        .DESCRIPTION
+        Resolve dependencies for a module based on the manifest file, following PSModuleInfo structure
+
+        .EXAMPLE
+        Resolve-PSModuleDependency -Path 'C:\MyModule\MyModule.psd1'
+
+        Installs all modules defined in the manifest file, following PSModuleInfo structure.
+
+        .NOTES
+        Should later be adapted to support both pre-reqs, and dependencies.
+        Should later be adapted to take 4 parameters sets: specific version ("requiredVersion" | "GUID"), latest version ModuleVersion,
+        and latest version within a range MinimumVersion - MaximumVersion.
+    #>
+    [Alias('Resolve-PSModuleDependencies')]
+    [CmdletBinding()]
+    param(
+        # The path to the manifest file.
+        [Parameter(Mandatory)]
+        [string] $ManifestFilePath
+    )
+
+    Write-Verbose 'Resolving dependencies'
+
+    $manifest = Import-PowerShellDataFile -Path $ManifestFilePath
+    Write-Verbose "Reading [$ManifestFilePath]"
+    Write-Verbose "Found [$($manifest.RequiredModules.Count)] modules to install"
+
+    foreach ($requiredModule in $manifest.RequiredModules) {
+        $installParams = @{}
+
+        if ($requiredModule -is [string]) {
+            $installParams.Name = $requiredModule
+        } else {
+            $installParams.Name = $requiredModule.ModuleName
+            $installParams.MinimumVersion = $requiredModule.ModuleVersion
+            $installParams.RequiredVersion = $requiredModule.RequiredVersion
+            $installParams.MaximumVersion = $requiredModule.MaximumVersion
+        }
+        $installParams.Force = $true
+        $installParams.Verbose = $false
+
+        Write-Verbose "[$($installParams.Name)] - Installing module"
+        $VerbosePreferenceOriginal = $VerbosePreference
+        $VerbosePreference = 'SilentlyContinue'
+        Install-Module @installParams -AllowPrerelease:$false
+        $VerbosePreference = $VerbosePreferenceOriginal
+        Write-Verbose "[$($installParams.Name)] - Importing module"
+        $VerbosePreferenceOriginal = $VerbosePreference
+        $VerbosePreference = 'SilentlyContinue'
+        Import-Module @installParams
+        $VerbosePreference = $VerbosePreferenceOriginal
+        Write-Verbose "[$($installParams.Name)] - Done"
+    }
+    Write-Verbose 'Resolving dependencies - Done'
+}

--- a/scripts/helpers/Test-PSModule.ps1
+++ b/scripts/helpers/Test-PSModule.ps1
@@ -111,8 +111,9 @@ function Test-PSModule {
             $containerParams = @{
                 Path = $moduleTestsPath
                 Data = @{
-                    Path    = $Path
-                    Verbose = $true
+                    Parameters = @{
+                        Path = $Path
+                    }
                 }
             }
             Write-Verbose 'ContainerParams:'

--- a/scripts/helpers/Test-PSModule.ps1
+++ b/scripts/helpers/Test-PSModule.ps1
@@ -127,6 +127,11 @@ function Test-PSModule {
 
     #region Import module
     if ((Test-Path -Path $moduleTestsPath) -and $testModule) {
+        Start-LogGroup "Install module dependencies"
+        $moduleManifestPath = Join-Path -Path $Path -ChildPath "$moduleName.psd1"
+        Resolve-PSModuleDependency -ManifestFilePath $moduleManifestPath
+        Stop-LogGroup
+
         Start-LogGroup "Importing module: $moduleName"
         Add-PSModulePath -Path (Split-Path $Path -Parent)
         Get-Module -Name $moduleName -ListAvailable | Remove-Module -Force

--- a/scripts/helpers/Test-PSModule.ps1
+++ b/scripts/helpers/Test-PSModule.ps1
@@ -111,9 +111,7 @@ function Test-PSModule {
             $containerParams = @{
                 Path = $moduleTestsPath
                 Data = @{
-                    Parameters = @{
-                        Path = $Path
-                    }
+                    Path = $Path
                 }
             }
             Write-Verbose 'ContainerParams:'
@@ -128,7 +126,7 @@ function Test-PSModule {
 
     #region Import module
     if ((Test-Path -Path $moduleTestsPath) -and $testModule) {
-        Start-LogGroup "Install module dependencies"
+        Start-LogGroup 'Install module dependencies'
         $moduleManifestPath = Join-Path -Path $Path -ChildPath "$moduleName.psd1"
         Resolve-PSModuleDependency -ManifestFilePath $moduleManifestPath
         Stop-LogGroup

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -34,14 +34,14 @@ Stop-LogGroup
 $failedTests = $results.FailedCount
 
 if ($failedTests -gt 0) {
-    Write-Output '::error::❌ Some tests failed.'
+    Write-Host '::error::❌ Some tests failed.'
     return $false
 }
 if ($results.Result -ne 'Passed') {
-    Write-Output '::error::❌ Some tests failed.'
+    Write-Host '::error::❌ Some tests failed.'
     return $false
 }
 if ($failedTests -eq 0) {
-    Write-Output '::notice::✅ All tests passed.'
+    Write-Host '::notice::✅ All tests passed.'
     return $true
 }

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -35,12 +35,13 @@ $failedTests = $results.FailedCount
 
 if ($failedTests -gt 0) {
     Write-Output '::error::❌ Some tests failed.'
-    exit $failedTests
+    return $false
 }
 if ($results.Result -ne 'Passed') {
     Write-Output '::error::❌ Some tests failed.'
-    exit 1
+    return $false
 }
 if ($failedTests -eq 0) {
     Write-Output '::notice::✅ All tests passed.'
+    return $true
 }


### PR DESCRIPTION
## Description

- Add output `passed`, containing if the tests passed.
- Add `Resolve-PSModuleDependency` to install and import all requirements before testing the module.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [x] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
