### PR TITLE
🩹 [Patch]: Move module import test to general tests

### DIFF
--- a/scripts/tests/PSModule/Common.Tests.ps1
+++ b/scripts/tests/PSModule/Common.Tests.ps1
@@ -11,31 +11,6 @@ Param(
 # These tests are for the whole module and its parts. The scope of these tests are on the src folder and the specific module folder within it.
 Describe 'Script files' {
     Context 'Module design tests' {
-        It 'Script filename and function/filter name should match' {
-            $scriptFiles = @()
-
-            Get-ChildItem -Path $Path -Filter '*.ps1' -Recurse -File | ForEach-Object {
-                $fileContent = Get-Content -Path $_.FullName -Raw
-                if ($fileContent -match '^(?:function|filter)\s+([a-zA-Z][a-zA-Z0-9-]*)') {
-                    $functionName = $matches[1]
-                    $fileName = $_.BaseName
-                    $relativePath = $_.FullName.Replace($Path, '').Trim('\').Trim('/')
-                    $scriptFiles += @{
-                        fileName     = $fileName
-                        filePath     = $relativePath
-                        functionName = $functionName
-                    }
-                }
-            }
-
-            $issues = @('')
-            $issues += $scriptFiles | Where-Object { $_.filename -ne $_.functionName } | ForEach-Object {
-                " - $($_.filePath): Function/filter name [$($_.functionName)]. Change file name or function/filter name so they match."
-            }
-            $issues -join [Environment]::NewLine |
-                Should -BeNullOrEmpty -Because 'the script files should be called the same as the function they contain'
-        }
-
         # It 'Script file should only contain one function or filter' {}
         # It 'All script files have tests' {} # Look for the folder name in tests called the same as section/folder name of functions
     }

--- a/scripts/tests/PSModule/Module.Tests.ps1
+++ b/scripts/tests/PSModule/Module.Tests.ps1
@@ -17,6 +17,16 @@ BeforeAll {
 }
 
 Describe 'PSModule - Module tests' {
+    Context 'Module' {
+        It 'The module should be available' {
+            Get-Module -Name $moduleName -ListAvailable | Should -Not -BeNullOrEmpty
+            Write-Verbose (Get-Module -Name $moduleName -ListAvailable | Out-String) -Verbose
+        }
+        It 'The module should be importable' {
+            { Import-Module -Name $moduleName -Verbose -RequiredVersion 999.0.0 -Force } | Should -Not -Throw
+        }
+    }
+
     Context "Module Manifest" {
         BeforeAll {
             $moduleManifestPath = Join-Path -Path $Path -ChildPath "$moduleName.psd1"
@@ -37,7 +47,4 @@ Describe 'PSModule - Module tests' {
         # It 'has a valid icon URL' {}
         # It 'has a valid help URL' {}
     }
-    # Context "Root module file" {
-    #     It 'has a root module file' {}
-    # }
 }

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -17,12 +17,9 @@ BeforeAll {
 }
 
 Describe 'PSModule - SourceCode tests' {
-
     Context 'function/filter' {
         It 'Script filename and function/filter name should match' {
-
             $scriptFiles = @()
-
             Get-ChildItem -Path $Path -Filter '*.ps1' -Recurse -File | ForEach-Object {
                 $fileContent = Get-Content -Path $_.FullName -Raw
                 if ($fileContent -match '^(?:function|filter)\s+([a-zA-Z][a-zA-Z0-9-]*)') {


### PR DESCRIPTION
## Description

- Move module import test to general tests, can now be removed from module code.
- Remove 'Script filename and function/filter name should match' from common, as its basically a source code test.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
