### PR TITLE
🩹 [Patch]: Add test where enabling `-Verbose` in a function is not allowed

### DIFF
--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -49,7 +49,7 @@ Describe 'PSModule - SourceCode tests' {
         It "Should not contain '-Verbose' unless it is disabled using ':`$false' qualifier after it" {
             $issues = @('')
             $scriptFiles | ForEach-Object {
-                Select-String -Path $_.FullName -Pattern '-Verbose(?!\:\$false)' -AllMatches | ForEach-Object {
+                Select-String -Path $_.FullName -Pattern '"(?<!Write-)Verbose(?!\:\$false)"' -AllMatches | ForEach-Object {
                     $issues += " - $($_.Path):L$($_.LineNumber)"
                 }
             }

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -46,16 +46,15 @@ Describe 'PSModule - SourceCode tests' {
 
         # It 'All script files have tests' {} # Look for the folder name in tests called the same as section/folder name of functions
 
-        It 'Should not contain a -Verbose switch which is not directly disabled using :$false' {
+        It "Should not contain '-Verbose' unless it is disabled using ':`$false' qualifier after it" {
             $issues = @('')
             $scriptFiles | ForEach-Object {
                 Select-String -Path $_.FullName -Pattern '-Verbose(?!\:\$false)' -AllMatches | ForEach-Object {
                     $issues += " - $($_.Path):L$($_.LineNumber)"
                 }
-
             }
             $issues -join [Environment]::NewLine |
-                Should -BeNullOrEmpty -Because 'the script should not contain a -Verbose switch which is not directly disabled using :$false'
+                Should -BeNullOrEmpty -Because "the script should not contain '-Verbose' unless it is disabled using ':`$false' qualifier after it."
         }
     }
 

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -49,7 +49,7 @@ Describe 'PSModule - SourceCode tests' {
         It "Should not contain '-Verbose' unless it is disabled using ':`$false' qualifier after it" {
             $issues = @('')
             $scriptFiles | ForEach-Object {
-                Select-String -Path $_.FullName -Pattern '"(?<!Write-)Verbose(?!\:\$false)"' -AllMatches | ForEach-Object {
+                Select-String -Path $_.FullName -Pattern '\s(-Verbose(?::\$true)?)\b(?!:\$false)' -AllMatches | ForEach-Object {
                     $issues += " - $($_.Path):L$($_.LineNumber)"
                 }
             }

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -46,6 +46,17 @@ Describe 'PSModule - SourceCode tests' {
 
         # It 'All script files have tests' {} # Look for the folder name in tests called the same as section/folder name of functions
 
+        It 'Should not contain a -Verbose switch which is not directly disabled using :$false' {
+            $issues = @('')
+            $scriptFiles | ForEach-Object {
+                Select-String -Path $_.FullName -Pattern '-Verbose(?!\:\$false)' -AllMatches | ForEach-Object {
+                    $issues += " - $($_.Path):L$($_.LineNumber)"
+                }
+
+            }
+            $issues -join [Environment]::NewLine |
+                Should -BeNullOrEmpty -Because 'the script should not contain a -Verbose switch which is not directly disabled using :$false'
+        }
     }
 
     Context 'Function/filter design' {

--- a/tests/src/finally.ps1
+++ b/tests/src/finally.ps1
@@ -1,3 +1,3 @@
-﻿Write-Verbose '------------------------------' -Verbose
-Write-Verbose '---  THIS IS A LAST LOADER ---' -Verbose
-Write-Verbose '------------------------------' -Verbose
+﻿Write-Verbose '------------------------------'
+Write-Verbose '---  THIS IS A LAST LOADER ---'
+Write-Verbose '------------------------------'

--- a/tests/src/init/initializer.ps1
+++ b/tests/src/init/initializer.ps1
@@ -1,3 +1,3 @@
-﻿Write-Verbose '-------------------------------' -Verbose
-Write-Verbose '---  THIS IS AN INITIALIZER ---' -Verbose
-Write-Verbose '-------------------------------' -Verbose
+﻿Write-Verbose '-------------------------------'
+Write-Verbose '---  THIS IS AN INITIALIZER ---'
+Write-Verbose '-------------------------------'

--- a/tests/src/init/initializer.ps1
+++ b/tests/src/init/initializer.ps1
@@ -1,3 +1,3 @@
-﻿Write-Verbose '-------------------------------'
-Write-Verbose '---  THIS IS AN INITIALIZER ---'
-Write-Verbose '-------------------------------'
+﻿Write-Verbose '-------------------------------' -Verbose -ErrorAction Stop
+Write-Verbose '---  THIS IS AN INITIALIZER ---' -Verbose:$true -ErrorAction Stop
+Write-Verbose '-------------------------------' -Verbose:$false -ErrorAction Stop

--- a/tests/src/init/initializer.ps1
+++ b/tests/src/init/initializer.ps1
@@ -1,3 +1,3 @@
-﻿Write-Verbose '-------------------------------' -Verbose -ErrorAction Stop
-Write-Verbose '---  THIS IS AN INITIALIZER ---' -Verbose:$true -ErrorAction Stop
-Write-Verbose '-------------------------------' -Verbose:$false -ErrorAction Stop
+﻿Write-Verbose '-------------------------------'
+Write-Verbose '---  THIS IS AN INITIALIZER ---'
+Write-Verbose '-------------------------------'

--- a/tests/src/scripts/loader.ps1
+++ b/tests/src/scripts/loader.ps1
@@ -1,3 +1,3 @@
-﻿Write-Verbose '-------------------------' -Verbose
-Write-Verbose '---  THIS IS A LOADER ---' -Verbose
-Write-Verbose '-------------------------' -Verbose
+﻿Write-Verbose '-------------------------'
+Write-Verbose '---  THIS IS A LOADER ---'
+Write-Verbose '-------------------------'

--- a/tests/srcWithManifest/finally.ps1
+++ b/tests/srcWithManifest/finally.ps1
@@ -1,3 +1,3 @@
-﻿Write-Verbose '------------------------------' -Verbose
-Write-Verbose '---  THIS IS A LAST LOADER ---' -Verbose
-Write-Verbose '------------------------------' -Verbose
+﻿Write-Verbose '------------------------------'
+Write-Verbose '---  THIS IS A LAST LOADER ---'
+Write-Verbose '------------------------------'

--- a/tests/srcWithManifest/init/initializer.ps1
+++ b/tests/srcWithManifest/init/initializer.ps1
@@ -1,3 +1,3 @@
-﻿Write-Verbose '-------------------------------' -Verbose
-Write-Verbose '---  THIS IS AN INITIALIZER ---' -Verbose
-Write-Verbose '-------------------------------' -Verbose
+﻿Write-Verbose '-------------------------------'
+Write-Verbose '---  THIS IS AN INITIALIZER ---'
+Write-Verbose '-------------------------------'

--- a/tests/srcWithManifest/scripts/loader.ps1
+++ b/tests/srcWithManifest/scripts/loader.ps1
@@ -1,3 +1,3 @@
-﻿Write-Verbose '-------------------------' -Verbose
-Write-Verbose '---  THIS IS A LOADER ---' -Verbose
-Write-Verbose '-------------------------' -Verbose
+﻿Write-Verbose '-------------------------'
+Write-Verbose '---  THIS IS A LOADER ---'
+Write-Verbose '-------------------------'


### PR DESCRIPTION
## Description

- One of the points of having `[Cmdletbinding()]` is to be able to turn on verbosity logging from outside the function. This test now checks for enabling switches `-Verbose` or `-Verbose:$true`.
  - Fixes #20 

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
