### PR TITLE
🩹 [Patch]: Add test to check that script files have `[CmdletBinding()]`

### DIFF
--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -92,11 +92,15 @@ Describe 'PSModule - SourceCode tests' {
         It 'should have [CmdletBinding()] attribute' {
             $issues = @('')
             $functionFiles | ForEach-Object {
+                $found = $false
                 $filePath = $_.FullName
+                Write-Verbose "Processing [$filePath]"
                 $scriptAst = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
                 $tokens = $scriptAst.FindAll({ $true }, $true)
                 foreach ($token in $tokens) {
+                    Write-Verbose "Looking at: [$($token.TypeName.Name)]"
                     if ($token.TypeName.Name -eq 'CmdletBinding') {
+                        Write-Verbose "--- Found CmdletBinding attribute"
                         $found = $true
                     }
                 }

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -68,7 +68,7 @@ Describe 'PSModule - SourceCode tests' {
                 Should -BeNullOrEmpty -Because "the script should use '`$null = <commands>' instead of '<commands> | Out-Null'"
         }
 
-        It "Should not use ternary operations for compatability reasons" {
+        It 'Should not use ternary operations for compatability reasons' {
             $issues = @('')
             $scriptFiles | ForEach-Object {
                 Select-String -Path $_.FullName -Pattern '(?<!\|)\s+\?' -AllMatches | ForEach-Object {
@@ -76,7 +76,7 @@ Describe 'PSModule - SourceCode tests' {
                 }
             }
             $issues -join [Environment]::NewLine |
-                Should -BeNullOrEmpty -Because "the script should not use ternary operations for compatability with PS 5.1 and below"
+                Should -BeNullOrEmpty -Because 'the script should not use ternary operations for compatability with PS 5.1 and below'
         }
     }
 
@@ -87,7 +87,22 @@ Describe 'PSModule - SourceCode tests' {
         # It 'has description for all functions' {}
         # It 'has examples for all functions' {}
         # It 'has output documentation for all functions' {}
-        # It 'has [CmdletBinding()] attribute' {}
+        It 'should have [CmdletBinding()] attribute' {
+            $issues = @('')
+            $scriptFiles | ForEach-Object {
+                $scriptFilePath = $_.FullName
+                $scriptAst = [System.Management.Automation.Language.Parser]::ParseFile($scriptFilePath, [ref]$null, [ref]$null)
+                $tokens = $scriptAst.FindAll({ $true }, $true)
+                foreach ($token in $tokens) {
+                    if ($token.TypeName.Name -eq 'CmdletBinding') {
+                        $issues += " - $($_.Extent.File)"
+                    }
+                }
+            }
+            $issues -join [Environment]::NewLine |
+                Should -BeNullOrEmpty -Because 'the script should have [CmdletBinding()] attribute'
+        }
+
         # It 'boolean parameters in CmdletBinding() attribute are written without assignments' {}
         #     I.e. [CmdletBinding(ShouldProcess)] instead of [CmdletBinding(ShouldProcess = $true)]
         # It 'has [OutputType()] attribute' {}

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -95,8 +95,11 @@ Describe 'PSModule - SourceCode tests' {
                 $tokens = $scriptAst.FindAll({ $true }, $true)
                 foreach ($token in $tokens) {
                     if ($token.TypeName.Name -eq 'CmdletBinding') {
-                        $issues += " - $($_.Extent.File)"
+                        $found = $true
                     }
+                }
+                if (-not $found) {
+                    $issues += " - $scriptFilePath"
                 }
             }
             $issues -join [Environment]::NewLine |

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -89,6 +89,7 @@ Describe 'PSModule - SourceCode tests' {
         # It 'has synopsis for all functions' {}
         # It 'has description for all functions' {}
         # It 'has examples for all functions' {}
+        
         It 'should have [CmdletBinding()] attribute' {
             $issues = @('')
             $functionFiles | ForEach-Object {

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -94,13 +94,10 @@ Describe 'PSModule - SourceCode tests' {
             $functionFiles | ForEach-Object {
                 $found = $false
                 $filePath = $_.FullName
-                Write-Verbose "Processing [$filePath]"
                 $scriptAst = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
                 $tokens = $scriptAst.FindAll({ $true }, $true)
                 foreach ($token in $tokens) {
-                    Write-Verbose "Looking at: [$($token.TypeName.Name)]"
                     if ($token.TypeName.Name -eq 'CmdletBinding') {
-                        Write-Verbose "--- Found CmdletBinding attribute"
                         $found = $true
                     }
                 }

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -9,14 +9,13 @@ Param(
 )
 
 BeforeAll {
-    [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
-        'PSUseDeclaredVarsMoreThanAssignments', '',
-        Justification = 'scriptFiles is used in the test.'
-    )]
     $scriptFiles = Get-ChildItem -Path $Path -Filter '*.ps1' -Recurse -File
     $functionFiles = Get-ChildItem -Directory -Path $Path |
         Where-Object { $_.Name -in 'public', 'private' } |
         Get-ChildItem -Filter '*.ps1' -File
+
+    Write-Verbose "Found $($scriptFiles.Count) script files in $Path"
+    Write-Verbose "Found $($functionFiles.Count) function files in $Path"
 }
 
 Describe 'PSModule - SourceCode tests' {
@@ -89,7 +88,7 @@ Describe 'PSModule - SourceCode tests' {
         # It 'has synopsis for all functions' {}
         # It 'has description for all functions' {}
         # It 'has examples for all functions' {}
-        
+
         It 'should have [CmdletBinding()] attribute' {
             $issues = @('')
             $functionFiles | ForEach-Object {

--- a/tests/src/public/Get-PSModuleTest.ps1
+++ b/tests/src/public/Get-PSModuleTest.ps1
@@ -10,7 +10,6 @@ function Get-PSModuleTest {
 
         "Hello, World!"
     #>
-    [CmdletBinding()]
     param (
         # Name of the person to greet.
         [Parameter(Mandatory)]

--- a/tests/src/public/Get-PSModuleTest.ps1
+++ b/tests/src/public/Get-PSModuleTest.ps1
@@ -10,6 +10,7 @@ function Get-PSModuleTest {
 
         "Hello, World!"
     #>
+    [CmdletBinding()]
     param (
         # Name of the person to greet.
         [Parameter(Mandatory)]


### PR DESCRIPTION
## Description

- Add test to check that script files have `[CmdletBinding()]`.
  - Fixes #13

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
