### PR TITLE
🩹 [Patch]: Script files should only contain one function

### DIFF
--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -20,6 +20,20 @@ BeforeAll {
 
 Describe 'PSModule - SourceCode tests' {
     Context 'function/filter' {
+        It 'Should contain one function or filter' {
+            $issues = @('')
+            $functionFiles | ForEach-Object {
+                $path = $_.FullName
+                $Ast = [System.Management.Automation.Language.Parser]::ParseFile($path, [ref]$null, [ref]$null)
+                $tokens = $Ast.FindAll( { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] } , $true )
+                if ($tokens.count -ne 1) {
+                    $issues += " - $path"
+                }
+            }
+            $issues -join [Environment]::NewLine |
+                Should -BeNullOrEmpty -Because 'the script should contain one function or filter'
+        }
+
         It 'Script filename and function/filter name should match' {
             $scriptFiles = @()
             Get-ChildItem -Path $Path -Filter '*.ps1' -Recurse -File | ForEach-Object {
@@ -44,7 +58,7 @@ Describe 'PSModule - SourceCode tests' {
                 Should -BeNullOrEmpty -Because 'the script files should be called the same as the function they contain'
         }
 
-        # It 'Script file should only contain one function or filter' {}
+
 
         # It 'All script files have tests' {} # Look for the folder name in tests called the same as section/folder name of functions
 

--- a/tests/src/public/Get-PSModuleTest.ps1
+++ b/tests/src/public/Get-PSModuleTest.ps1
@@ -18,3 +18,22 @@ function Get-PSModuleTest {
     )
     Write-Output "Hello, $Name!"
 }
+
+filter Get-PSModuleTestfilter {
+    <#
+        .SYNOPSIS
+        Performs tests on a module.
+
+        .EXAMPLE
+        Test-PSModule -Name 'World'
+
+        "Hello, World!"
+    #>
+    [CmdletBinding()]
+    param (
+        # Name of the person to greet.
+        [Parameter(Mandatory)]
+        [string] $Name
+    )
+    Write-Output "Hello, $Name!"
+}

--- a/tests/src/public/Get-PSModuleTest.ps1
+++ b/tests/src/public/Get-PSModuleTest.ps1
@@ -18,22 +18,3 @@ function Get-PSModuleTest {
     )
     Write-Output "Hello, $Name!"
 }
-
-filter Get-PSModuleTestfilter {
-    <#
-        .SYNOPSIS
-        Performs tests on a module.
-
-        .EXAMPLE
-        Test-PSModule -Name 'World'
-
-        "Hello, World!"
-    #>
-    [CmdletBinding()]
-    param (
-        # Name of the person to greet.
-        [Parameter(Mandatory)]
-        [string] $Name
-    )
-    Write-Output "Hello, $Name!"
-}


### PR DESCRIPTION
## Description

- Add test to check that a function file only contains one function/filter.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
