### PR TITLE
🩹 [Patch]: Remove the need for module path for module specific tests

### DIFF
--- a/scripts/helpers/Test-PSModule.ps1
+++ b/scripts/helpers/Test-PSModule.ps1
@@ -116,9 +116,6 @@
             LogGroup "Add test - Module - $moduleName" {
                 $containerParams = @{
                     Path = $moduleTestsPath
-                    Data = @{
-                        Path = $Path
-                    }
                 }
                 Write-Verbose 'ContainerParams:'
                 Write-Verbose "$($containerParams | ConvertTo-Json)"


### PR DESCRIPTION
## Description

- Remove the need for the `Path` for module specific tests. This was used earlier for running load tests of the module. No longer needed as this is default in the action.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
