### PR TITLE
🩹 [Patch]: Set Pester `StackTraceVerbosity` default to `Filtered`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ jobs:
 | `TestType` | The type of tests to run. Can be either `Module` or `SourceCode`.  | `true` | |
 | `Name` | The name of the module to test. The name of the repository is used if not specified. | `false` | |
 | `TestsPath` | The path to the tests to run. | `false` | `tests` |
-| `StackTraceVerbosity` | Verbosity level of the stack trace. Allowed values: `None`, `FirstLine`, `Filtered`, `Full`. | `false` | `None` |
+| `StackTraceVerbosity` | Verbosity level of the stack trace. Allowed values: `None`, `FirstLine`, `Filtered`, `Full`. | `false` | `Filtered` |
 | `Verbosity` | Verbosity level of the test output. Allowed values: `None`, `Normal`, `Detailed`, `Diagnostic`. | `false` | `Detailed` |
 
 ### Outputs

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
   StackTraceVerbosity:
     description: "Verbosity level of the stack trace. Allowed values: 'None', 'FirstLine', 'Filtered', 'Full'."
     required: false
-    default: 'None'
+    default: 'Filtered'
   Verbosity:
     description: "Verbosity level of the test output. Allowed values: 'None', 'Normal', 'Detailed', 'Diagnostic'."
     required: false

--- a/scripts/helpers/Test-PSModule.ps1
+++ b/scripts/helpers/Test-PSModule.ps1
@@ -26,7 +26,7 @@
         # Verbosity level of the stack trace.
         [Parameter()]
         [ValidateSet('None', 'FirstLine', 'Filtered', 'Full')]
-        [string] $StackTraceVerbosity = 'None',
+        [string] $StackTraceVerbosity = 'Filtered',
 
         # Verbosity level of the test output.
         [Parameter()]


### PR DESCRIPTION
## Description

- Set Pester `StackTraceVerbosity` default to `Filtered`

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
