### PR TITLE
🩹 [Patch]: Enable verbose and debug output preferences in action script

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ jobs:
 | `TestsPath` | The path to the tests to run. | `false` | `tests` |
 | `StackTraceVerbosity` | Verbosity level of the stack trace. Allowed values: `None`, `FirstLine`, `Filtered`, `Full`. | `false` | `Filtered` |
 | `Verbosity` | Verbosity level of the test output. Allowed values: `None`, `Normal`, `Detailed`, `Diagnostic`. | `false` | `Detailed` |
+| `VerbosePreference` | The preference for verbose output. Allowed values: `SilentlyContinue`, `Stop`, `Continue`, `Inquire`, `Break`, `Ignore`, `Suspend`. | `false` | `SilentlyContinue` |
+| `DebugPreference` | The preference for debug output. Allowed values: `SilentlyContinue`, `Stop`, `Continue`, `Inquire`, `Break`, `Ignore`, `Suspend`. | `false` | `SilentlyContinue` |
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,14 @@ inputs:
     description: "Verbosity level of the test output. Allowed values: 'None', 'Normal', 'Detailed', 'Diagnostic'."
     required: false
     default: 'Detailed'
+  VerbosePreference:
+    description: "The preference for verbose output. Allowed values: 'SilentlyContinue', 'Stop', 'Continue', 'Inquire', 'Break', 'Ignore','Suspend'."
+    required: false
+    default: 'SilentlyContinue'
+  DebugPreference:
+    description: "The preference for debug output. Allowed values: 'SilentlyContinue', 'Stop', 'Continue', 'Inquire', 'Break', 'Ignore','Suspend'."
+    required: false
+    default: 'SilentlyContinue'
 
 outputs:
   passed:
@@ -49,10 +57,12 @@ runs:
         GITHUB_ACTION_INPUT_TestsPath: ${{ inputs.TestsPath }}
         GITHUB_ACTION_INPUT_StackTraceVerbosity: ${{ inputs.StackTraceVerbosity }}
         GITHUB_ACTION_INPUT_Verbosity: ${{ inputs.Verbosity }}
+        GITHUB_ACTION_INPUT_VerbosePreference: ${{ inputs.VerbosePreference }}
+        GITHUB_ACTION_INPUT_DebugPreference: ${{ inputs.DebugPreference }}
       run: |
         # Test-PSModule
-        $VerbosePreference = 'Continue'
-        $DebugPreference = 'Continue'
+        $VerbosePreference = $env:GITHUB_ACTION_INPUT_VerbosePreference
+        $DebugPreference = $env:GITHUB_ACTION_INPUT_DebugPreference
         $passed = . "${{ github.action_path }}\scripts\main.ps1" -Verbose
         "passed=$passed" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 

--- a/action.yml
+++ b/action.yml
@@ -51,6 +51,8 @@ runs:
         GITHUB_ACTION_INPUT_Verbosity: ${{ inputs.Verbosity }}
       run: |
         # Test-PSModule
+        $VerbosePreference = 'Continue'
+        $DebugPreference = 'Continue'
         $passed = . "${{ github.action_path }}\scripts\main.ps1" -Verbose
         "passed=$passed" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 


### PR DESCRIPTION
## Description

This pull request includes updates to the verbosity and debug preferences for test outputs in the `README.md` and `action.yml` files. The most important changes include adding new input parameters for `VerbosePreference` and `DebugPreference` and updating the run commands to utilize these new parameters.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R106-R107): Added descriptions for `VerbosePreference` and `DebugPreference` options to the list of job inputs.

Configuration updates:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R30-R37): Added `VerbosePreference` and `DebugPreference` as new input parameters with descriptions and default values.
* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R60-R65): Updated the `runs` section to include the new `VerbosePreference` and `DebugPreference` parameters and set their values in the run commands.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
