### PR TITLE
🪲 [Fix]: Disable Debug dialogs for tests

### DIFF
--- a/.github/workflows/Action-Test-Src-Default.yml
+++ b/.github/workflows/Action-Test-Src-Default.yml
@@ -45,6 +45,6 @@ jobs:
           PASSED: ${{ steps.action-test.outputs.passed }}
         run: |
           Write-Host "Passed: [$env:PASSED]"
-          if ($env:PASSED -eq 'False') {
+          if ($env:PASSED -ne 'true') {
             exit 1
           }

--- a/.github/workflows/Action-Test-Src-Default.yml
+++ b/.github/workflows/Action-Test-Src-Default.yml
@@ -34,8 +34,6 @@ jobs:
           Name: PSModuleTest
           Path: tests/src
           TestType: SourceCode
-          DebugPreference: 'Continue'
-          VerbosePreference: 'Continue'
 
       - name: Status
         shell: pwsh

--- a/.github/workflows/Action-Test-Src-Default.yml
+++ b/.github/workflows/Action-Test-Src-Default.yml
@@ -42,11 +42,9 @@ jobs:
       - name: Status
         shell: pwsh
         env:
-          result: ${{ steps.action-test.outputs.result }}
+          PASSED: ${{ steps.action-test.outputs.passed }}
         run: |
-          $result = $env:result | ConvertFrom-Json
-          $passed = $result.Passed
-          Write-Host "Passed: [$Passed]"
-          if ($passed -eq 'False') {
+          Write-Host "Passed: [$env:PASSED]"
+          if ($env:PASSED -eq 'False') {
             exit 1
           }

--- a/.github/workflows/Action-Test-Src-Default.yml
+++ b/.github/workflows/Action-Test-Src-Default.yml
@@ -34,6 +34,8 @@ jobs:
           Name: PSModuleTest
           Path: tests/src
           TestType: SourceCode
+          DebugPreference: 'Continue'
+          VerbosePreference: 'Continue'
 
       - name: Status
         shell: pwsh

--- a/.github/workflows/Action-Test-Src-Default.yml
+++ b/.github/workflows/Action-Test-Src-Default.yml
@@ -2,7 +2,11 @@ name: Action-Test [Src-Default]
 
 run-name: "Action-Test [Src-Default] - [${{ github.event.pull_request.title }} #${{ github.event.pull_request.number }}] by @${{ github.actor }}"
 
-on: [pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/Action-Test-Src-Default.yml
+++ b/.github/workflows/Action-Test-Src-Default.yml
@@ -41,8 +41,11 @@ jobs:
 
       - name: Status
         shell: pwsh
+        env:
+          result: ${{ steps.action-test.outputs.result }}
         run: |
-          $passed = '${{ steps.action-test.outputs.passed }}'
+          $result = $env:result | ConvertFrom-Json
+          $passed = $result.Passed
           Write-Host "Passed: [$Passed]"
           if ($passed -eq 'False') {
             exit 1

--- a/.github/workflows/Action-Test-Src-WithManifest.yml
+++ b/.github/workflows/Action-Test-Src-WithManifest.yml
@@ -45,6 +45,6 @@ jobs:
           PASSED: ${{ steps.action-test.outputs.passed }}
         run: |
           Write-Host "Passed: [$env:PASSED]"
-          if ($env:PASSED -eq 'False') {
+          if ($env:PASSED -ne 'true') {
             exit 1
           }

--- a/.github/workflows/Action-Test-Src-WithManifest.yml
+++ b/.github/workflows/Action-Test-Src-WithManifest.yml
@@ -41,9 +41,10 @@ jobs:
 
       - name: Status
         shell: pwsh
+        env:
+          PASSED: ${{ steps.action-test.outputs.passed }}
         run: |
-          $passed = '${{ steps.action-test.outputs.passed }}'
-          Write-Host "Passed: [$Passed]"
-          if ($passed -eq 'False') {
+          Write-Host "Passed: [$env:PASSED]"
+          if ($env:PASSED -eq 'False') {
             exit 1
           }

--- a/.github/workflows/Action-Test-Src-WithManifest.yml
+++ b/.github/workflows/Action-Test-Src-WithManifest.yml
@@ -2,7 +2,11 @@ name: Action-Test [Src-WithManifest]
 
 run-name: "Action-Test [Src-WithManifest] - [${{ github.event.pull_request.title }} #${{ github.event.pull_request.number }}] by @${{ github.actor }}"
 
-on: [pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/Action-Test-outputs.yml
+++ b/.github/workflows/Action-Test-outputs.yml
@@ -45,6 +45,6 @@ jobs:
           PASSED: ${{ steps.action-test.outputs.passed }}
         run: |
           Write-Host "Passed: [$env:PASSED]"
-          if ($env:PASSED -eq 'False') {
+          if ($env:PASSED -ne 'true') {
             exit 1
           }

--- a/.github/workflows/Action-Test-outputs.yml
+++ b/.github/workflows/Action-Test-outputs.yml
@@ -2,7 +2,11 @@ name: Action-Test [outputs]
 
 run-name: "Action-Test [outputs] - [${{ github.event.pull_request.title }} #${{ github.event.pull_request.number }}] by @${{ github.actor }}"
 
-on: [pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/Action-Test-outputs.yml
+++ b/.github/workflows/Action-Test-outputs.yml
@@ -41,9 +41,10 @@ jobs:
 
       - name: Status
         shell: pwsh
+        env:
+          PASSED: ${{ steps.action-test.outputs.passed }}
         run: |
-          $passed = '${{ steps.action-test.outputs.passed }}'
-          Write-Host "Passed: [$Passed]"
-          if ($passed -eq 'False') {
+          Write-Host "Passed: [$env:PASSED]"
+          if ($env:PASSED -eq 'False') {
             exit 1
           }

--- a/.github/workflows/Action-Test-outputs.yml
+++ b/.github/workflows/Action-Test-outputs.yml
@@ -34,7 +34,6 @@ jobs:
           Name: PSModuleTest
           Path: tests/outputs/modules
           TestType: Module
-          DebugPreference: Continue
 
       - name: Status
         shell: pwsh

--- a/.github/workflows/Action-Test-outputs.yml
+++ b/.github/workflows/Action-Test-outputs.yml
@@ -34,6 +34,7 @@ jobs:
           Name: PSModuleTest
           Path: tests/outputs/modules
           TestType: Module
+          DebugPreference: Continue
 
       - name: Status
         shell: pwsh

--- a/README.md
+++ b/README.md
@@ -103,8 +103,10 @@ jobs:
 | `TestsPath` | The path to the tests to run. | `false` | `tests` |
 | `StackTraceVerbosity` | Verbosity level of the stack trace. Allowed values: `None`, `FirstLine`, `Filtered`, `Full`. | `false` | `Filtered` |
 | `Verbosity` | Verbosity level of the test output. Allowed values: `None`, `Normal`, `Detailed`, `Diagnostic`. | `false` | `Detailed` |
-| `VerbosePreference` | The preference for verbose output. Allowed values: `SilentlyContinue`, `Stop`, `Continue`, `Inquire`, `Break`, `Ignore`, `Suspend`. | `false` | `SilentlyContinue` |
-| `DebugPreference` | The preference for debug output. Allowed values: `SilentlyContinue`, `Stop`, `Continue`, `Inquire`, `Break`, `Ignore`, `Suspend`. | `false` | `SilentlyContinue` |
+| `Debug` | Enable debug output. | `'false'` | `false` |
+| `Verbose` | Enable verbose output. | `'false'` | `false` |
+| `Version` | Specifies the version of the GitHub module to be installed. The value must be an exact version. | | `false` |
+| `Prerelease` | Allow prerelease versions if available. | `'false'` | `false` |
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -69,10 +69,9 @@ runs:
         Script: |
           # Test-PSModule
           $passed = . "${{ github.action_path }}\scripts\main.ps1"
-          "passed=$passed" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Set-GitHubOutput -Name 'passed' -Value $passed
 
           Write-Host "Passed: [$passed]"
-
           if (-not $passed) {
             exit 1
           }

--- a/action.yml
+++ b/action.yml
@@ -61,8 +61,8 @@ runs:
         GITHUB_ACTION_INPUT_DebugPreference: ${{ inputs.DebugPreference }}
       run: |
         # Test-PSModule
-        $VerbosePreference = $env:GITHUB_ACTION_INPUT_VerbosePreference
-        $DebugPreference = $env:GITHUB_ACTION_INPUT_DebugPreference
+        # $VerbosePreference = $env:GITHUB_ACTION_INPUT_VerbosePreference
+        # $DebugPreference = $env:GITHUB_ACTION_INPUT_DebugPreference
         $passed = . "${{ github.action_path }}\scripts\main.ps1" -Verbose
         "passed=$passed" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 

--- a/action.yml
+++ b/action.yml
@@ -63,8 +63,8 @@ runs:
         GITHUB_ACTION_INPUT_DebugPreference: ${{ inputs.DebugPreference }}
       run: |
         # Test-PSModule
-        # $VerbosePreference = $env:GITHUB_ACTION_INPUT_VerbosePreference
-        # $DebugPreference = $env:GITHUB_ACTION_INPUT_DebugPreference
+        $VerbosePreference = $env:GITHUB_ACTION_INPUT_VerbosePreference
+        $DebugPreference = $env:GITHUB_ACTION_INPUT_DebugPreference
         $passed = . "${{ github.action_path }}\scripts\main.ps1"
         "passed=$passed" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
   StackTraceVerbosity:
     description: "Verbosity level of the stack trace. Allowed values: 'None', 'FirstLine', 'Filtered', 'Full'."
     required: false
-    default: 'Filtered'
+    default: 'Full'
   Verbosity:
     description: "Verbosity level of the test output. Allowed values: 'None', 'Normal', 'Detailed', 'Diagnostic'."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ inputs:
   StackTraceVerbosity:
     description: "Verbosity level of the stack trace. Allowed values: 'None', 'FirstLine', 'Filtered', 'Full'."
     required: false
-    default: 'Full'
+    default: 'Filtered'
   Verbosity:
     description: "Verbosity level of the test output. Allowed values: 'None', 'Normal', 'Detailed', 'Diagnostic'."
     required: false

--- a/action.yml
+++ b/action.yml
@@ -46,7 +46,7 @@ inputs:
 outputs:
   passed:
     description: If the tests passed.
-    value: ${{ steps.test.outputs.passed }}
+    value: ${{ fromJSON(steps.test.outputs.result).passed }}
 
 runs:
   using: composite
@@ -68,13 +68,7 @@ runs:
         Version: ${{ inputs.Version }}
         Script: |
           # Test-PSModule
-          $passed = . "${{ github.action_path }}\scripts\main.ps1"
-          Set-GitHubOutput -Name 'passed' -Value $passed
-
-          Write-Host "Passed: [$passed]"
-          if (-not $passed) {
-            exit 1
-          }
+          . "${{ github.action_path }}\scripts\main.ps1"
 
     - name: Upload test results
       uses: actions/upload-artifact@v4

--- a/action.yml
+++ b/action.yml
@@ -30,11 +30,13 @@ inputs:
   VerbosePreference:
     description: "The preference for verbose output. Allowed values: 'SilentlyContinue', 'Stop', 'Continue', 'Inquire', 'Break', 'Ignore','Suspend'."
     required: false
-    default: 'SilentlyContinue'
+    # default: 'SilentlyContinue'
+    default: 'Continue'
   DebugPreference:
     description: "The preference for debug output. Allowed values: 'SilentlyContinue', 'Stop', 'Continue', 'Inquire', 'Break', 'Ignore','Suspend'."
     required: false
-    default: 'SilentlyContinue'
+    # default: 'SilentlyContinue'
+    default: 'Continue'
 
 outputs:
   passed:
@@ -61,8 +63,8 @@ runs:
         GITHUB_ACTION_INPUT_DebugPreference: ${{ inputs.DebugPreference }}
       run: |
         # Test-PSModule
-        # $VerbosePreference = $env:GITHUB_ACTION_INPUT_VerbosePreference
-        # $DebugPreference = $env:GITHUB_ACTION_INPUT_DebugPreference
+        $VerbosePreference = $env:GITHUB_ACTION_INPUT_VerbosePreference
+        $DebugPreference = $env:GITHUB_ACTION_INPUT_DebugPreference
         $passed = . "${{ github.action_path }}\scripts\main.ps1"
         "passed=$passed" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 

--- a/action.yml
+++ b/action.yml
@@ -27,16 +27,21 @@ inputs:
     description: "Verbosity level of the test output. Allowed values: 'None', 'Normal', 'Detailed', 'Diagnostic'."
     required: false
     default: 'Detailed'
-  VerbosePreference:
-    description: "The preference for verbose output. Allowed values: 'SilentlyContinue', 'Stop', 'Continue', 'Inquire', 'Break', 'Ignore','Suspend'."
+  Debug:
+    description: Enable debug output.
     required: false
-    # default: 'SilentlyContinue'
-    default: 'Continue'
-  DebugPreference:
-    description: "The preference for debug output. Allowed values: 'SilentlyContinue', 'Stop', 'Continue', 'Inquire', 'Break', 'Ignore','Suspend'."
+    default: 'false'
+  Verbose:
+    description: Enable verbose output.
     required: false
-    # default: 'SilentlyContinue'
-    default: 'Continue'
+    default: 'false'
+  Version:
+    description: Specifies the version of the GitHub module to be installed. The value must be an exact version.
+    required: false
+  Prerelease:
+    description: Allow prerelease versions if available.
+    required: false
+    default: 'false'
 
 outputs:
   passed:
@@ -48,9 +53,6 @@ runs:
   steps:
     - name: Run Test-PSModule
       uses: PSModule/GitHub-Script@v1
-
-    - name: Run Test-PSModule
-      shell: pwsh
       id: test
       env:
         GITHUB_ACTION_INPUT_Name: ${{ inputs.Name }}
@@ -59,20 +61,21 @@ runs:
         GITHUB_ACTION_INPUT_TestsPath: ${{ inputs.TestsPath }}
         GITHUB_ACTION_INPUT_StackTraceVerbosity: ${{ inputs.StackTraceVerbosity }}
         GITHUB_ACTION_INPUT_Verbosity: ${{ inputs.Verbosity }}
-        GITHUB_ACTION_INPUT_VerbosePreference: ${{ inputs.VerbosePreference }}
-        GITHUB_ACTION_INPUT_DebugPreference: ${{ inputs.DebugPreference }}
-      run: |
-        # Test-PSModule
-        $VerbosePreference = $env:GITHUB_ACTION_INPUT_VerbosePreference
-        $DebugPreference = $env:GITHUB_ACTION_INPUT_DebugPreference
-        $passed = . "${{ github.action_path }}\scripts\main.ps1"
-        "passed=$passed" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+      with:
+        Debug: ${{ inputs.Debug }}
+        Prerelease: ${{ inputs.Prerelease }}
+        Verbose: ${{ inputs.Verbose }}
+        Version: ${{ inputs.Version }}
+        Script: |
+          # Test-PSModule
+          $passed = . "${{ github.action_path }}\scripts\main.ps1"
+          "passed=$passed" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
-        Write-Host "Passed: [$passed]"
+          Write-Host "Passed: [$passed]"
 
-        if (-not $passed) {
-          exit 1
-        }
+          if (-not $passed) {
+            exit 1
+          }
 
     - name: Upload test results
       uses: actions/upload-artifact@v4

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ runs:
         # Test-PSModule
         # $VerbosePreference = $env:GITHUB_ACTION_INPUT_VerbosePreference
         # $DebugPreference = $env:GITHUB_ACTION_INPUT_DebugPreference
-        $passed = . "${{ github.action_path }}\scripts\main.ps1" -Verbose
+        $passed = . "${{ github.action_path }}\scripts\main.ps1"
         "passed=$passed" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 
         Write-Host "Passed: [$passed]"

--- a/action.yml
+++ b/action.yml
@@ -63,8 +63,8 @@ runs:
         GITHUB_ACTION_INPUT_DebugPreference: ${{ inputs.DebugPreference }}
       run: |
         # Test-PSModule
-        $VerbosePreference = $env:GITHUB_ACTION_INPUT_VerbosePreference
-        $DebugPreference = $env:GITHUB_ACTION_INPUT_DebugPreference
+        # $VerbosePreference = $env:GITHUB_ACTION_INPUT_VerbosePreference
+        # $DebugPreference = $env:GITHUB_ACTION_INPUT_DebugPreference
         $passed = . "${{ github.action_path }}\scripts\main.ps1"
         "passed=$passed" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
 

--- a/scripts/helpers/Test-PSModule.ps1
+++ b/scripts/helpers/Test-PSModule.ps1
@@ -59,8 +59,8 @@
             Data = @{
                 Path             = $Path
                 SettingsFilePath = $settingsFilePath
-                Verbose          = $env:GITHUB_ACTION_INPUT_VerbosePreference
-                Debug            = $env:GITHUB_ACTION_INPUT_DebugPreference
+                Verbose          = $env:GITHUB_ACTION_INPUT_VerbosePreference -eq 'Continue'
+                Debug            = $env:GITHUB_ACTION_INPUT_DebugPreference -eq 'Continue'
             }
         }
         Write-Verbose 'ContainerParams:'
@@ -73,8 +73,8 @@
             Path = Join-Path -Path $PSScriptRoot -ChildPath '..\tests\PSModule\Common.Tests.ps1'
             Data = @{
                 Path    = $Path
-                Verbose = $env:GITHUB_ACTION_INPUT_VerbosePreference
-                Debug   = $env:GITHUB_ACTION_INPUT_DebugPreference
+                Verbose = $env:GITHUB_ACTION_INPUT_VerbosePreference -eq 'Continue'
+                Debug   = $env:GITHUB_ACTION_INPUT_DebugPreference -eq 'Continue'
             }
         }
         Write-Verbose 'ContainerParams:'
@@ -88,8 +88,8 @@
                 Path = Join-Path -Path $PSScriptRoot -ChildPath '..\tests\PSModule\Module.Tests.ps1'
                 Data = @{
                     Path    = $Path
-                    Verbose = $env:GITHUB_ACTION_INPUT_VerbosePreference
-                    Debug   = $env:GITHUB_ACTION_INPUT_DebugPreference
+                    Verbose = $env:GITHUB_ACTION_INPUT_VerbosePreference -eq 'Continue'
+                    Debug   = $env:GITHUB_ACTION_INPUT_DebugPreference -eq 'Continue'
                 }
             }
             Write-Verbose 'ContainerParams:'
@@ -105,8 +105,8 @@
                 Data = @{
                     Path      = $Path
                     TestsPath = $moduleTestsPath
-                    Verbose   = $env:GITHUB_ACTION_INPUT_VerbosePreference
-                    Debug     = $env:GITHUB_ACTION_INPUT_DebugPreference
+                    Verbose   = $env:GITHUB_ACTION_INPUT_VerbosePreference -eq 'Continue'
+                    Debug     = $env:GITHUB_ACTION_INPUT_DebugPreference -eq 'Continue'
                 }
             }
             Write-Verbose 'ContainerParams:'
@@ -120,8 +120,8 @@
             LogGroup "Add test - Module - $moduleName" {
                 $containerParams = @{
                     Path    = $moduleTestsPath
-                    Verbose = $env:GITHUB_ACTION_INPUT_VerbosePreference
-                    Debug   = $env:GITHUB_ACTION_INPUT_DebugPreference
+                    Verbose = $env:GITHUB_ACTION_INPUT_VerbosePreference -eq 'Continue'
+                    Debug   = $env:GITHUB_ACTION_INPUT_DebugPreference -eq 'Continue'
                 }
                 Write-Verbose 'ContainerParams:'
                 Write-Verbose "$($containerParams | ConvertTo-Json)"

--- a/scripts/helpers/Test-PSModule.ps1
+++ b/scripts/helpers/Test-PSModule.ps1
@@ -70,7 +70,7 @@
         $containerParams = @{
             Path = Join-Path -Path $PSScriptRoot -ChildPath '..\tests\PSModule\Common.Tests.ps1'
             Data = @{
-                Path    = $Path
+                Path = $Path
             }
         }
         Write-Verbose 'ContainerParams:'
@@ -83,7 +83,7 @@
             $containerParams = @{
                 Path = Join-Path -Path $PSScriptRoot -ChildPath '..\tests\PSModule\Module.Tests.ps1'
                 Data = @{
-                    Path    = $Path
+                    Path = $Path
                 }
             }
             Write-Verbose 'ContainerParams:'
@@ -111,7 +111,7 @@
         if (Test-Path -Path $moduleTestsPath) {
             LogGroup "Add test - Module - $moduleName" {
                 $containerParams = @{
-                    Path    = $moduleTestsPath
+                    Path = $moduleTestsPath
                 }
                 Write-Verbose 'ContainerParams:'
                 Write-Verbose "$($containerParams | ConvertTo-Json)"

--- a/scripts/helpers/Test-PSModule.ps1
+++ b/scripts/helpers/Test-PSModule.ps1
@@ -157,7 +157,7 @@
                     PassThru  = $true
                 }
                 Debug        = @{
-                    WriteDebugMessages = $env:GITHUB_ACTION_INPUT_DebugPreference
+                    WriteDebugMessages    = $env:GITHUB_ACTION_INPUT_DebugPreference = 'Continue'
                     ShowNavigationMarkers = $true
 
                 }

--- a/scripts/helpers/Test-PSModule.ps1
+++ b/scripts/helpers/Test-PSModule.ps1
@@ -59,7 +59,6 @@
             Data = @{
                 Path             = $Path
                 SettingsFilePath = $settingsFilePath
-                Verbose          = $env:GITHUB_ACTION_INPUT_VerbosePreference -eq 'Continue'
             }
         }
         Write-Verbose 'ContainerParams:'
@@ -72,7 +71,6 @@
             Path = Join-Path -Path $PSScriptRoot -ChildPath '..\tests\PSModule\Common.Tests.ps1'
             Data = @{
                 Path    = $Path
-                Verbose = $env:GITHUB_ACTION_INPUT_VerbosePreference -eq 'Continue'
             }
         }
         Write-Verbose 'ContainerParams:'
@@ -86,7 +84,6 @@
                 Path = Join-Path -Path $PSScriptRoot -ChildPath '..\tests\PSModule\Module.Tests.ps1'
                 Data = @{
                     Path    = $Path
-                    Verbose = $env:GITHUB_ACTION_INPUT_VerbosePreference -eq 'Continue'
                 }
             }
             Write-Verbose 'ContainerParams:'
@@ -102,7 +99,6 @@
                 Data = @{
                     Path      = $Path
                     TestsPath = $moduleTestsPath
-                    Verbose   = $env:GITHUB_ACTION_INPUT_VerbosePreference -eq 'Continue'
                 }
             }
             Write-Verbose 'ContainerParams:'
@@ -116,7 +112,6 @@
             LogGroup "Add test - Module - $moduleName" {
                 $containerParams = @{
                     Path    = $moduleTestsPath
-                    Verbose = $env:GITHUB_ACTION_INPUT_VerbosePreference -eq 'Continue'
                 }
                 Write-Verbose 'ContainerParams:'
                 Write-Verbose "$($containerParams | ConvertTo-Json)"
@@ -151,9 +146,6 @@
                     Container = $containers
                     PassThru  = $true
                 }
-                # Debug        = @{
-                #     WriteDebugMessages = $env:GITHUB_ACTION_INPUT_DebugPreference -eq 'Continue'
-                # }
                 TestResult   = @{
                     Enabled       = $testModule
                     OutputFormat  = 'NUnitXml'
@@ -181,8 +173,8 @@
     #region Run tests
     $verbosePref = $VerbosePreference
     $debugPref = $DebugPreference
-    # $VerbosePreference = $env:GITHUB_ACTION_INPUT_DebugPreference
-    # $DebugPreference = $env:GITHUB_ACTION_INPUT_DebugPreference
+    $VerbosePreference = $env:GITHUB_ACTION_INPUT_DebugPreference
+    $DebugPreference = $env:GITHUB_ACTION_INPUT_DebugPreference
     $results = Invoke-Pester @pesterParams
     $VerbosePreference = $verbosePref
     $DebugPreference = $debugPref

--- a/scripts/helpers/Test-PSModule.ps1
+++ b/scripts/helpers/Test-PSModule.ps1
@@ -59,6 +59,8 @@
             Data = @{
                 Path             = $Path
                 SettingsFilePath = $settingsFilePath
+                Debug            = $false
+                Verbose          = $false
             }
         }
         Write-Verbose 'ContainerParams:'
@@ -70,7 +72,9 @@
         $containerParams = @{
             Path = Join-Path -Path $PSScriptRoot -ChildPath '..\tests\PSModule\Common.Tests.ps1'
             Data = @{
-                Path = $Path
+                Path    = $Path
+                Debug   = $false
+                Verbose = $false
             }
         }
         Write-Verbose 'ContainerParams:'
@@ -83,7 +87,9 @@
             $containerParams = @{
                 Path = Join-Path -Path $PSScriptRoot -ChildPath '..\tests\PSModule\Module.Tests.ps1'
                 Data = @{
-                    Path = $Path
+                    Path    = $Path
+                    Debug   = $false
+                    Verbose = $false
                 }
             }
             Write-Verbose 'ContainerParams:'
@@ -99,6 +105,8 @@
                 Data = @{
                     Path      = $Path
                     TestsPath = $moduleTestsPath
+                    Debug     = $false
+                    Verbose   = $false
                 }
             }
             Write-Verbose 'ContainerParams:'
@@ -171,15 +179,8 @@
     }
 
     #region Run tests
-    $verbosePref = $VerbosePreference
-    $debugPref = $DebugPreference
-    $VerbosePreference = $env:GITHUB_ACTION_INPUT_DebugPreference
-    $DebugPreference = $env:GITHUB_ACTION_INPUT_DebugPreference
     $results = Invoke-Pester @pesterParams
-    $VerbosePreference = $verbosePref
-    $DebugPreference = $debugPref
     #endregion
-
 
     $results
 }

--- a/scripts/helpers/Test-PSModule.ps1
+++ b/scripts/helpers/Test-PSModule.ps1
@@ -179,8 +179,15 @@
     }
 
     #region Run tests
+    $verbosePref = $VerbosePreference
+    $debugPref = $DebugPreference
+    $VerbosePreference = $env:GITHUB_ACTION_INPUT_DebugPreference
+    $DebugPreference = $env:GITHUB_ACTION_INPUT_DebugPreference
     $results = Invoke-Pester @pesterParams
+    $VerbosePreference = $verbosePref
+    $DebugPreference = $debugPref
     #endregion
+
 
     $results
 }

--- a/scripts/helpers/Test-PSModule.ps1
+++ b/scripts/helpers/Test-PSModule.ps1
@@ -151,9 +151,9 @@
                     Container = $containers
                     PassThru  = $true
                 }
-                Debug        = @{
-                    WriteDebugMessages = $env:GITHUB_ACTION_INPUT_DebugPreference -eq 'Continue'
-                }
+                # Debug        = @{
+                #     WriteDebugMessages = $env:GITHUB_ACTION_INPUT_DebugPreference -eq 'Continue'
+                # }
                 TestResult   = @{
                     Enabled       = $testModule
                     OutputFormat  = 'NUnitXml'

--- a/scripts/helpers/Test-PSModule.ps1
+++ b/scripts/helpers/Test-PSModule.ps1
@@ -181,7 +181,6 @@
     #region Run tests
     $results = Invoke-Pester @pesterParams
     #endregion
-    
 
     $results
 }

--- a/scripts/helpers/Test-PSModule.ps1
+++ b/scripts/helpers/Test-PSModule.ps1
@@ -181,8 +181,8 @@
     #region Run tests
     $verbosePref = $VerbosePreference
     $debugPref = $DebugPreference
-    $VerbosePreference = $env:GITHUB_ACTION_INPUT_DebugPreference
-    $DebugPreference = $env:GITHUB_ACTION_INPUT_DebugPreference
+    # $VerbosePreference = $env:GITHUB_ACTION_INPUT_DebugPreference
+    # $DebugPreference = $env:GITHUB_ACTION_INPUT_DebugPreference
     $results = Invoke-Pester @pesterParams
     $VerbosePreference = $verbosePref
     $DebugPreference = $debugPref

--- a/scripts/helpers/Test-PSModule.ps1
+++ b/scripts/helpers/Test-PSModule.ps1
@@ -60,7 +60,6 @@
                 Path             = $Path
                 SettingsFilePath = $settingsFilePath
                 Verbose          = $env:GITHUB_ACTION_INPUT_VerbosePreference -eq 'Continue'
-                Debug            = $env:GITHUB_ACTION_INPUT_DebugPreference -eq 'Continue'
             }
         }
         Write-Verbose 'ContainerParams:'
@@ -74,7 +73,6 @@
             Data = @{
                 Path    = $Path
                 Verbose = $env:GITHUB_ACTION_INPUT_VerbosePreference -eq 'Continue'
-                Debug   = $env:GITHUB_ACTION_INPUT_DebugPreference -eq 'Continue'
             }
         }
         Write-Verbose 'ContainerParams:'
@@ -89,7 +87,6 @@
                 Data = @{
                     Path    = $Path
                     Verbose = $env:GITHUB_ACTION_INPUT_VerbosePreference -eq 'Continue'
-                    Debug   = $env:GITHUB_ACTION_INPUT_DebugPreference -eq 'Continue'
                 }
             }
             Write-Verbose 'ContainerParams:'
@@ -106,7 +103,6 @@
                     Path      = $Path
                     TestsPath = $moduleTestsPath
                     Verbose   = $env:GITHUB_ACTION_INPUT_VerbosePreference -eq 'Continue'
-                    Debug     = $env:GITHUB_ACTION_INPUT_DebugPreference -eq 'Continue'
                 }
             }
             Write-Verbose 'ContainerParams:'
@@ -121,7 +117,6 @@
                 $containerParams = @{
                     Path    = $moduleTestsPath
                     Verbose = $env:GITHUB_ACTION_INPUT_VerbosePreference -eq 'Continue'
-                    Debug   = $env:GITHUB_ACTION_INPUT_DebugPreference -eq 'Continue'
                 }
                 Write-Verbose 'ContainerParams:'
                 Write-Verbose "$($containerParams | ConvertTo-Json)"
@@ -157,7 +152,7 @@
                     PassThru  = $true
                 }
                 Debug        = @{
-                    WriteDebugMessages = $env:GITHUB_ACTION_INPUT_DebugPreference = 'Continue'
+                    WriteDebugMessages = $env:GITHUB_ACTION_INPUT_DebugPreference -eq 'Continue'
                 }
                 TestResult   = @{
                     Enabled       = $testModule
@@ -184,13 +179,7 @@
     }
 
     #region Run tests
-    $verbosepref = $VerbosePreference
-    $debugpref = $DebugPreference
-    $VerbosePreference = $env:GITHUB_ACTION_INPUT_VerbosePreference
-    $DebugPreference = $env:GITHUB_ACTION_INPUT_DebugPreference
     $results = Invoke-Pester @pesterParams
-    $VerbosePreference = $verbosepref
-    $DebugPreference = $debugpref
     #endregion
 
     $results

--- a/scripts/helpers/Test-PSModule.ps1
+++ b/scripts/helpers/Test-PSModule.ps1
@@ -131,9 +131,9 @@
         LogGroup "Importing module: $moduleName" {
             Add-PSModulePath -Path (Split-Path $Path -Parent)
             $existingModule = Get-Module -Name $ModuleName -ListAvailable
-            $existingModule | Remove-Module -Force -Verbose
-            $existingModule.RequiredModules | ForEach-Object { $_ | Remove-Module -Force -Verbose -ErrorAction SilentlyContinue }
-            $existingModule.NestedModules | ForEach-Object { $_ | Remove-Module -Force -Verbose -ErrorAction SilentlyContinue }
+            $existingModule | Remove-Module -Force
+            $existingModule.RequiredModules | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
+            $existingModule.NestedModules | ForEach-Object { $_ | Remove-Module -Force -ErrorAction SilentlyContinue }
             Import-Module -Name $moduleName -Force -RequiredVersion '999.0.0' -Global
         }
     }

--- a/scripts/helpers/Test-PSModule.ps1
+++ b/scripts/helpers/Test-PSModule.ps1
@@ -156,6 +156,11 @@
                     Container = $containers
                     PassThru  = $true
                 }
+                Debug        = @{
+                    WriteDebugMessages = $env:GITHUB_ACTION_INPUT_DebugPreference
+                    ShowNavigationMarkers = $true
+
+                }
                 TestResult   = @{
                     Enabled       = $testModule
                     OutputFormat  = 'NUnitXml'

--- a/scripts/helpers/Test-PSModule.ps1
+++ b/scripts/helpers/Test-PSModule.ps1
@@ -157,9 +157,7 @@
                     PassThru  = $true
                 }
                 Debug        = @{
-                    WriteDebugMessages    = $env:GITHUB_ACTION_INPUT_DebugPreference = 'Continue'
-                    ShowNavigationMarkers = $true
-
+                    WriteDebugMessages = $env:GITHUB_ACTION_INPUT_DebugPreference = 'Continue'
                 }
                 TestResult   = @{
                     Enabled       = $testModule

--- a/scripts/main.ps1
+++ b/scripts/main.ps1
@@ -56,13 +56,13 @@ $failedTests = $results.FailedCount
 
 if ($failedTests -gt 0) {
     Write-Host '::error::❌ Some tests failed.'
-    return $false
 }
 if ($results.Result -ne 'Passed') {
     Write-Host '::error::❌ Some tests failed.'
-    return $false
 }
 if ($failedTests -eq 0) {
     Write-Host '::notice::✅ All tests passed.'
-    return $true
 }
+
+Set-GitHubOutput -Name 'passed' -Value ($failedTests -eq 0)
+exit $failedTests

--- a/scripts/tests/PSModule/Module.Tests.ps1
+++ b/scripts/tests/PSModule/Module.Tests.ps1
@@ -20,27 +20,27 @@ Describe 'PSModule - Module tests' {
     Context 'Module' {
         It 'The module should be available' {
             Get-Module -Name $moduleName -ListAvailable | Should -Not -BeNullOrEmpty
-            Write-Verbose (Get-Module -Name $moduleName -ListAvailable | Out-String) -Verbose
+            Write-Verbose (Get-Module -Name $moduleName -ListAvailable | Out-String)
         }
         It 'The module should be importable' {
-            { Import-Module -Name $moduleName -Verbose -RequiredVersion 999.0.0 -Force } | Should -Not -Throw
+            { Import-Module -Name $moduleName -RequiredVersion 999.0.0 -Force } | Should -Not -Throw
         }
     }
 
     Context "Module Manifest" {
         BeforeAll {
             $moduleManifestPath = Join-Path -Path $Path -ChildPath "$moduleName.psd1"
-            Write-Verbose "Module Manifest Path: [$moduleManifestPath]" -Verbose
+            Write-Verbose "Module Manifest Path: [$moduleManifestPath]"
         }
         It 'Module Manifest exists' {
             $result = Test-Path -Path $moduleManifestPath
             $result | Should -Be $true
-            Write-Verbose $result -Verbose
+            Write-Verbose $result
         }
         It 'Module Manifest is valid' {
             $result = Test-ModuleManifest -Path $moduleManifestPath
             $result | Should -Not -Be $null
-            Write-Verbose $result -Verbose
+            Write-Verbose $result
         }
         # It 'has a valid license URL' {}
         # It 'has a valid project URL' {}

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -15,7 +15,7 @@ BeforeAll {
     $scriptFiles = Get-ChildItem -Path $Path -Include *.psm1, *.ps1 -Recurse -File
     LogGroup 'Script files:' {
         $scriptFiles | ForEach-Object {
-            Write-Verbose " - $($_.FullName)" -Verbose
+            Write-Verbose " - $($_.FullName)"
         }
     }
     $functionsPath = Join-Path -Path $Path -ChildPath 'functions'
@@ -27,9 +27,9 @@ BeforeAll {
     $functionFiles = (Test-Path -Path $functionsPath) ? (Get-ChildItem -Path $functionsPath -Filter '*.ps1' -File) : $null
     $publicFunctionFiles = (Test-Path -Path $publicFunctionsPath) ? (Get-ChildItem -Path $publicFunctionsPath -File -Filter '*.ps1' -Recurse) : $null
 
-    Write-Verbose "Found $($scriptFiles.Count) script files in [$Path]" -Verbose
-    Write-Verbose "Found $($functionFiles.Count) function files in [$functionsPath]" -Verbose
-    Write-Verbose "Found $($publicFunctionFiles.Count) public function files in [$publicFunctionsPath]" -Verbose
+    Write-Verbose "Found $($scriptFiles.Count) script files in [$Path]"
+    Write-Verbose "Found $($functionFiles.Count) function files in [$functionsPath]"
+    Write-Verbose "Found $($publicFunctionFiles.Count) public function files in [$publicFunctionsPath]"
 }
 
 Describe 'PSModule - SourceCode tests' {

--- a/tests/outputs/modules/PSModuleTest/PSModuleTest.psm1
+++ b/tests/outputs/modules/PSModuleTest/PSModuleTest.psm1
@@ -267,6 +267,7 @@ function Get-PSModuleTest {
         [Parameter(Mandatory)]
         [string] $Name
     )
+    Write-Debug 'Debug message'
     Write-Output "Hello, $Name!"
 }
 
@@ -319,13 +320,15 @@ function Set-PSModuleTest {
         'PSUseShouldProcessForStateChangingFunctions', '', Scope = 'Function',
         Justification = 'Reason for suppressing'
     )]
-    [CmdletBinding()]
+    [CmdletBinding(SupportsShouldProcess)]
     param (
         # Name of the person to greet.
         [Parameter(Mandatory)]
         [string] $Name
     )
-    Write-Output "Hello, $Name!"
+    if ($PSCmdlet.ShouldProcess($Name, 'Set-PSModuleTest')) {
+        Write-Output "Hello, $Name!"
+    }
 }
 
 Write-Verbose "[$scriptName] - [/public/Set-PSModuleTest.ps1] - Done"

--- a/tests/outputs/modules/PSModuleTest/PSModuleTest.psm1
+++ b/tests/outputs/modules/PSModuleTest/PSModuleTest.psm1
@@ -24,9 +24,9 @@ Write-Verbose "[$scriptName] - [/init] - Processing folder"
 #region - From /init/initializer.ps1
 Write-Verbose "[$scriptName] - [/init/initializer.ps1] - Importing"
 
-Write-Verbose '-------------------------------' -Verbose
-Write-Verbose '---  THIS IS AN INITIALIZER ---' -Verbose
-Write-Verbose '-------------------------------' -Verbose
+Write-Verbose '-------------------------------'
+Write-Verbose '---  THIS IS AN INITIALIZER ---'
+Write-Verbose '-------------------------------'
 
 Write-Verbose "[$scriptName] - [/init/initializer.ps1] - Done"
 #endregion - From /init/initializer.ps1
@@ -371,9 +371,9 @@ Write-Verbose "[$scriptName] - [/public] - Done"
 #region - From /finally.ps1
 Write-Verbose "[$scriptName] - [/finally.ps1] - Importing"
 
-Write-Verbose '------------------------------' -Verbose
-Write-Verbose '---  THIS IS A LAST LOADER ---' -Verbose
-Write-Verbose '------------------------------' -Verbose
+Write-Verbose '------------------------------'
+Write-Verbose '---  THIS IS A LAST LOADER ---'
+Write-Verbose '------------------------------'
 Write-Verbose "[$scriptName] - [/finally.ps1] - Done"
 #endregion - From /finally.ps1
 

--- a/tests/outputs/modules/PSModuleTest/PSModuleTest.psm1
+++ b/tests/outputs/modules/PSModuleTest/PSModuleTest.psm1
@@ -268,6 +268,7 @@ function Get-PSModuleTest {
         [string] $Name
     )
     Write-Debug 'Debug message'
+    Write-Verbose 'Verbose message'
     Write-Output "Hello, $Name!"
 }
 
@@ -298,6 +299,8 @@ function New-PSModuleTest {
         [Parameter(Mandatory)]
         [string] $Name
     )
+    Write-Debug 'Debug message'
+    Write-Verbose 'Verbose message'
     Write-Output "Hello, $Name!"
 }
 
@@ -326,6 +329,8 @@ function Set-PSModuleTest {
         [Parameter(Mandatory)]
         [string] $Name
     )
+    Write-Debug 'Debug message'
+    Write-Verbose 'Verbose message'
     if ($PSCmdlet.ShouldProcess($Name, 'Set-PSModuleTest')) {
         Write-Output "Hello, $Name!"
     }
@@ -352,6 +357,8 @@ function Test-PSModuleTest {
         [Parameter(Mandatory)]
         [string] $Name
     )
+    Write-Debug 'Debug message'
+    Write-Verbose 'Verbose message'
     Write-Output "Hello, $Name!"
 }
 

--- a/tests/outputs/modules/PSModuleTest/scripts/loader.ps1
+++ b/tests/outputs/modules/PSModuleTest/scripts/loader.ps1
@@ -1,3 +1,3 @@
-﻿Write-Verbose '-------------------------' -Verbose
-Write-Verbose '---  THIS IS A LOADER ---' -Verbose
-Write-Verbose '-------------------------' -Verbose
+﻿Write-Verbose '-------------------------'
+Write-Verbose '---  THIS IS A LOADER ---'
+Write-Verbose '-------------------------'

--- a/tests/src/functions/public/New-PSModuleTest.ps1
+++ b/tests/src/functions/public/New-PSModuleTest.ps1
@@ -27,6 +27,7 @@ function New-PSModuleTest {
         [Parameter(Mandatory)]
         [string] $Name
     )
+    Write-Debug "Debug message"
     Write-Output "Hello, $Name!"
 }
 

--- a/tests/tests/PSModuleTest.Tests.ps1
+++ b/tests/tests/PSModuleTest.Tests.ps1
@@ -1,17 +1,13 @@
 ﻿
 Describe 'Module' {
-    BeforeEach {
-        $DebugPreference = 'Continue'
-    }
-
     It 'Function: Get-PSModuleTest' {
-        Get-PSModuleTest -Name 'World' -Verbose | Should -Be 'Hello, World!'
+        Get-PSModuleTest -Name 'World' | Should -Be 'Hello, World!'
     }
     It 'Function: New-PSModuleTest' {
         New-PSModuleTest -Name 'World' | Should -Be 'Hello, World!'
     }
     It 'Function: Set-PSModuleTest' {
-        Set-PSModuleTest -Name 'World' -Verbose | Should -Be 'Hello, World!'
+        Set-PSModuleTest -Name 'World' | Should -Be 'Hello, World!'
     }
     It 'Function: Test-PSModuleTest' {
         Test-PSModuleTest -Name 'World' | Should -Be 'Hello, World!'

--- a/tests/tests/PSModuleTest.Tests.ps1
+++ b/tests/tests/PSModuleTest.Tests.ps1
@@ -1,4 +1,8 @@
-﻿Describe 'Module' {
+﻿BeforeAll{
+    $DebugPreference = 'Continue'
+}
+
+Describe 'Module' {
     It 'Function: Get-PSModuleTest' {
         Get-PSModuleTest -Name 'World' -Verbose | Should -Be 'Hello, World!'
     }
@@ -6,7 +10,7 @@
         New-PSModuleTest -Name 'World' | Should -Be 'Hello, World!'
     }
     It 'Function: Set-PSModuleTest' {
-        Set-PSModuleTest -Name 'World' -Debug -Verbose | Should -Be 'Hello, World!'
+        Set-PSModuleTest -Name 'World' -Verbose | Should -Be 'Hello, World!'
     }
     It 'Function: Test-PSModuleTest' {
         Test-PSModuleTest -Name 'World' | Should -Be 'Hello, World!'

--- a/tests/tests/PSModuleTest.Tests.ps1
+++ b/tests/tests/PSModuleTest.Tests.ps1
@@ -1,8 +1,9 @@
-﻿BeforeAll{
-    $DebugPreference = 'Continue'
-}
-
+﻿
 Describe 'Module' {
+    BeforeEach {
+        $DebugPreference = 'Continue'
+    }
+
     It 'Function: Get-PSModuleTest' {
         Get-PSModuleTest -Name 'World' -Verbose | Should -Be 'Hello, World!'
     }

--- a/tests/tests/PSModuleTest.Tests.ps1
+++ b/tests/tests/PSModuleTest.Tests.ps1
@@ -1,5 +1,4 @@
-﻿
-Describe 'Module' {
+﻿Describe 'Module' {
     It 'Function: Get-PSModuleTest' {
         Get-PSModuleTest -Name 'World' | Should -Be 'Hello, World!'
     }

--- a/tests/tests/PSModuleTest.Tests.ps1
+++ b/tests/tests/PSModuleTest.Tests.ps1
@@ -1,12 +1,12 @@
 ﻿Describe 'Module' {
     It 'Function: Get-PSModuleTest' {
-        Get-PSModuleTest -Name 'World' | Should -Be 'Hello, World!'
+        Get-PSModuleTest -Name 'World' -Verbose | Should -Be 'Hello, World!'
     }
     It 'Function: New-PSModuleTest' {
         New-PSModuleTest -Name 'World' | Should -Be 'Hello, World!'
     }
     It 'Function: Set-PSModuleTest' {
-        Set-PSModuleTest -Name 'World' | Should -Be 'Hello, World!'
+        Set-PSModuleTest -Name 'World' -Debug -Verbose | Should -Be 'Hello, World!'
     }
     It 'Function: Test-PSModuleTest' {
         Test-PSModuleTest -Name 'World' | Should -Be 'Hello, World!'


### PR DESCRIPTION
## Description

This pull request includes several changes to GitHub Actions workflows and the `action.yml` configuration. The changes aim to add new triggers, update environment variable handling, and improve the clarity and functionality of the debug and verbose settings.

### Workflow Triggers and Environment Variables:

* [`.github/workflows/Action-Test-Src-Default.yml`](diffhunk://#diff-8ecb4765631346daa3fc827a56e509b7e8c1db0fc5ce7e3736bfea19531c0779L5-R9): Added `workflow_dispatch` and `schedule` triggers, and updated the `Status` job to use environment variables for the `PASSED` output. [[1]](diffhunk://#diff-8ecb4765631346daa3fc827a56e509b7e8c1db0fc5ce7e3736bfea19531c0779L5-R9) [[2]](diffhunk://#diff-8ecb4765631346daa3fc827a56e509b7e8c1db0fc5ce7e3736bfea19531c0779L37-R48)
* [`.github/workflows/Action-Test-Src-WithManifest.yml`](diffhunk://#diff-6b415bfca4385019a4a012a0677a3f583897f8c0ed23335673a87fc7962f0aecL5-R9): Added `workflow_dispatch` and `schedule` triggers, and updated the `Status` job to use environment variables for the `PASSED` output. [[1]](diffhunk://#diff-6b415bfca4385019a4a012a0677a3f583897f8c0ed23335673a87fc7962f0aecL5-R9) [[2]](diffhunk://#diff-6b415bfca4385019a4a012a0677a3f583897f8c0ed23335673a87fc7962f0aecR44-R48)
* [`.github/workflows/Action-Test-outputs.yml`](diffhunk://#diff-0d613011b57a43efc563d0da352dd07193e4d4c51d18b3960d164386b56500c9L5-R9): Added `workflow_dispatch` and `schedule` triggers, and updated the `Status` job to use environment variables for the `PASSED` output. [[1]](diffhunk://#diff-0d613011b57a43efc563d0da352dd07193e4d4c51d18b3960d164386b56500c9L5-R9) [[2]](diffhunk://#diff-0d613011b57a43efc563d0da352dd07193e4d4c51d18b3960d164386b56500c9R44-R48)

### Action Configuration:

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L25-L51): Changed the default values for `StackTraceVerbosity` and added new inputs for `Debug`, `Verbose`, `Version`, and `Prerelease`. Updated the `runs` section to use these new inputs. [[1]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L25-L51) [[2]](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6L60-R71)

### Script Updates:

* [`scripts/helpers/Test-PSModule.ps1`](diffhunk://#diff-2100eb52126417766eeb5b98f9c6a0da1dd10302b3b7c05d476295e3bd76ce76L76-R77): Removed the handling of `VerbosePreference` and `DebugPreference` environment variables, setting `Debug` and `Verbose` to `false` by default. (Ffc65297L56R56, [[1]](diffhunk://#diff-2100eb52126417766eeb5b98f9c6a0da1dd10302b3b7c05d476295e3bd76ce76L76-R77) [[2]](diffhunk://#diff-2100eb52126417766eeb5b98f9c6a0da1dd10302b3b7c05d476295e3bd76ce76L91-R92) [[3]](diffhunk://#diff-2100eb52126417766eeb5b98f9c6a0da1dd10302b3b7c05d476295e3bd76ce76L108-R109) [[4]](diffhunk://#diff-2100eb52126417766eeb5b98f9c6a0da1dd10302b3b7c05d476295e3bd76ce76L123-L124) [[5]](diffhunk://#diff-2100eb52126417766eeb5b98f9c6a0da1dd10302b3b7c05d476295e3bd76ce76L144-R144) [[6]](diffhunk://#diff-2100eb52126417766eeb5b98f9c6a0da1dd10302b3b7c05d476295e3bd76ce76L159-L161) [[7]](diffhunk://#diff-2100eb52126417766eeb5b98f9c6a0da1dd10302b3b7c05d476295e3bd76ce76L187-L193)
* [`scripts/main.ps1`](diffhunk://#diff-dc2e5a659836b1b73abb03421c567f5018c2755677c4a0aa764cb26117b68011L59-R68): Updated the script to set the GitHub output for `passed` based on the number of failed tests and exit with the count of failed tests.

### Test Scripts:

* [`scripts/tests/PSModule/Module.Tests.ps1`](diffhunk://#diff-48702d5fcb50be6ea65629693b0ea1148719b628d5f825228220aac8230d742eL23-R43): Removed redundant `-Verbose` flags from `Write-Verbose` calls.
* [`scripts/tests/PSModule/SourceCode.Tests.ps1`](diffhunk://#diff-fac42e72562e6968b058e80b8aa9f1f6e542a372a5aec978297f34464edc4e64L18-R18): Removed redundant `-Verbose` flags from `Write-Verbose` calls. [[1]](diffhunk://#diff-fac42e72562e6968b058e80b8aa9f1f6e542a372a5aec978297f34464edc4e64L18-R18) [[2]](diffhunk://#diff-fac42e72562e6968b058e80b8aa9f1f6e542a372a5aec978297f34464edc4e64L30-R32)

### Module Script Updates:

* [`tests/outputs/modules/PSModuleTest/PSModuleTest.psm1`](diffhunk://#diff-34f1c18d0e8aa3e7c0bef371f694885466666ae95b30af7f635b0177223aa4a7L27-R29): Added `Write-Debug` and `Write-Verbose` messages, and updated `Set-PSModuleTest` to support `ShouldProcess`. Removed redundant `-Verbose` flags from `Write-Verbose` calls. [[1]](diffhunk://#diff-34f1c18d0e8aa3e7c0bef371f694885466666ae95b30af7f635b0177223aa4a7L27-R29) [[2]](diffhunk://#diff-34f1c18d0e8aa3e7c0bef371f694885466666ae95b30af7f635b0177223aa4a7R270-R271) [[3]](diffhunk://#diff-34f1c18d0e8aa3e7c0bef371f694885466666ae95b30af7f635b0177223aa4a7R302-R303) [[4]](diffhunk://#diff-34f1c18d0e8aa3e7c0bef371f694885466666ae95b30af7f635b0177223aa4a7L322-R337) [[5]](diffhunk://#diff-34f1c18d0e8aa3e7c0bef371f694885466666ae95b30af7f635b0177223aa4a7R360-R361) [[6]](diffhunk://#diff-34f1c18d0e8aa3e7c0bef371f694885466666ae95b30af7f635b0177223aa4a7L364-R376)

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
