### PR TITLE
🩹 [Patch]; Disable ternary check

### DIFF
--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -123,7 +123,7 @@ Describe 'PSModule - SourceCode tests' {
                 Should -BeNullOrEmpty -Because "the script should use '`$null = ...' instead of '... | Out-Null'"
         }
 
-        It 'Should not use ternary operations for compatability reasons' {
+        It 'Should not use ternary operations for compatability reasons' -Skip {
             $issues = @('')
             $scriptFiles | ForEach-Object {
                 $filePath = $_.FullName


### PR DESCRIPTION
## Description

We implemented a ternary check to not use that in the scripts for compatibility reasons. Now that we don't focus on supporting 5.1 we no longer need this compatibility check.

* [`scripts/tests/PSModule/SourceCode.Tests.ps1`](diffhunk://#diff-fac42e72562e6968b058e80b8aa9f1f6e542a372a5aec978297f34464edc4e64L126-R126): Modified the test 'Should not use ternary operations for compatibility reasons' to be skipped.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
