### PR TITLE
🚀 [Feature]: Enable skips on SourceCode.PSModule tests

### DIFF
--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -1,4 +1,4 @@
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
     'PSReviewUnusedParameter', '',
     Justification = 'Parameters are used in the test.'
 )]
@@ -164,7 +164,8 @@ Describe 'PSModule - SourceCode tests' {
                 $Ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
                 $tokens = $Ast.FindAll( { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] } , $true )
                 $functionName = $tokens.Name
-                if ($functionsInTestFiles -notcontains $functionName) {
+                # If the file contains a function and the function name is not in the test files, add it as an issue.
+                if ($functionName.count -eq 1 -and $functionsInTestFiles -notcontains $functionName) {
                     $issues += " - $relativePath - $functionName"
                 }
             }

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -110,7 +110,7 @@ Describe 'PSModule - SourceCode tests' {
                     $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:NumberOfProcessors:(?<Reason>.+)' -AllMatches
                     if ($skipTest.Matches.Count -gt 0) {
                         $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                        Write-Verbose " - $relativePath - $skipReason" -Verbose
+                        Write-GitHubWarning " - $relativePath - $skipReason"
                         continue
                     }
                     $issues += " - $($_.Path):L$($_.LineNumber)"
@@ -127,7 +127,7 @@ Describe 'PSModule - SourceCode tests' {
                 $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:Verbose:(?<Reason>.+)' -AllMatches
                 if ($skipTest.Matches.Count -gt 0) {
                     $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                    Write-Verbose " - $relativePath - $skipReason" -Verbose
+                    Write-GitHubWarning " - $relativePath - $skipReason"
                     continue
                 }
                 Select-String -Path $filePath -Pattern '\s(-Verbose(?::\$true)?)\b(?!:\$false)' -AllMatches | ForEach-Object {
@@ -145,7 +145,7 @@ Describe 'PSModule - SourceCode tests' {
                 $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:OutNull:(?<Reason>.+)' -AllMatches
                 if ($skipTest.Matches.Count -gt 0) {
                     $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                    Write-Verbose " - $relativePath - $skipReason" -Verbose
+                    Write-GitHubWarning " - $relativePath - $skipReason"
                     continue
                 }
                 Select-String -Path $filePath -Pattern 'Out-Null' -AllMatches | ForEach-Object {
@@ -163,7 +163,7 @@ Describe 'PSModule - SourceCode tests' {
                 $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:NoTernary:(?<Reason>.+)' -AllMatches
                 if ($skipTest.Matches.Count -gt 0) {
                     $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                    Write-Verbose " - $relativePath - $skipReason" -Verbose
+                    Write-GitHubWarning " - $relativePath - $skipReason"
                     continue
                 }
                 Select-String -Path $filePath -Pattern '(?<!\|)\s+\?\s' -AllMatches | ForEach-Object {
@@ -181,7 +181,7 @@ Describe 'PSModule - SourceCode tests' {
                 $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:LowercaseKeywords:(?<Reason>.+)' -AllMatches
                 if ($skipTest.Matches.Count -gt 0) {
                     $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                    Write-Verbose " - $relativePath - $skipReason" -Verbose
+                    Write-GitHubWarning " - $relativePath - $skipReason"
                     continue
                 }
                 $errors = $null
@@ -237,7 +237,7 @@ Describe 'PSModule - SourceCode tests' {
                     $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:FunctionCount:(?<Reason>.+)' -AllMatches
                     if ($skipTest.Matches.Count -gt 0) {
                         $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                        Write-Verbose " - $relativePath - $skipReason" -Verbose
+                        Write-GitHubWarning " - $relativePath - $skipReason"
                         continue
                     }
                     $Ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
@@ -258,7 +258,7 @@ Describe 'PSModule - SourceCode tests' {
                     $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:FunctionName:(?<Reason>.+)' -AllMatches
                     if ($skipTest.Matches.Count -gt 0) {
                         $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                        Write-Verbose " - $relativePath - $skipReason" -Verbose
+                        Write-GitHubWarning " - $relativePath - $skipReason"
                         continue
                     }
                     $Ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
@@ -279,7 +279,7 @@ Describe 'PSModule - SourceCode tests' {
                     $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:CmdletBinding:(?<Reason>.+)' -AllMatches
                     if ($skipTest.Matches.Count -gt 0) {
                         $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                        Write-Verbose " - $relativePath - $skipReason" -Verbose
+                        Write-GitHubWarning " - $relativePath - $skipReason"
                         continue
                     }
                     $scriptAst = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
@@ -305,7 +305,7 @@ Describe 'PSModule - SourceCode tests' {
                     $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:ParamBlock:(?<Reason>.+)' -AllMatches
                     if ($skipTest.Matches.Count -gt 0) {
                         $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                        Write-Verbose " - $relativePath - $skipReason" -Verbose
+                        Write-GitHubWarning " - $relativePath - $skipReason"
                         continue
                     }
                     $scriptAst = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
@@ -357,7 +357,7 @@ Describe 'PSModule - SourceCode tests' {
                     $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:FunctionTest:(?<Reason>.+)' -AllMatches
                     if ($skipTest.Matches.Count -gt 0) {
                         $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                        Write-Verbose " - $relativePath - $skipReason" -Verbose
+                        Write-GitHubWarning " - $relativePath - $skipReason"
                         continue
                     }
                     $Ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -107,9 +107,10 @@ Describe 'PSModule - SourceCode tests' {
                 Select-String -Path $_.FullName -Pattern '\$env:NUMBER_OF_PROCESSORS' -AllMatches | ForEach-Object {
                     $filePath = $_.FullName
                     $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
-                    $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
-                    if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'NumberOfProcessors') {
-                        Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
+                    $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:NumberOfProcessors:(?<Reason>.+)' -AllMatches
+                    if ($skipTest.Matches.Count -gt 0) {
+                        $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
+                        Write-Verbose " - $relativePath - $skipReason" -Verbose
                         continue
                     }
                     $issues += " - $($_.Path):L$($_.LineNumber)"
@@ -123,9 +124,10 @@ Describe 'PSModule - SourceCode tests' {
             $scriptFiles | ForEach-Object {
                 $filePath = $_.FullName
                 $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
-                $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
-                if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'Verbose') {
-                    Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
+                $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:Verbose:(?<Reason>.+)' -AllMatches
+                if ($skipTest.Matches.Count -gt 0) {
+                    $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
+                    Write-Verbose " - $relativePath - $skipReason" -Verbose
                     continue
                 }
                 Select-String -Path $filePath -Pattern '\s(-Verbose(?::\$true)?)\b(?!:\$false)' -AllMatches | ForEach-Object {
@@ -140,9 +142,10 @@ Describe 'PSModule - SourceCode tests' {
             $scriptFiles | ForEach-Object {
                 $filePath = $_.FullName
                 $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
-                $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
-                if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'OutNull') {
-                    Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
+                $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:OutNull:(?<Reason>.+)' -AllMatches
+                if ($skipTest.Matches.Count -gt 0) {
+                    $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
+                    Write-Verbose " - $relativePath - $skipReason" -Verbose
                     continue
                 }
                 Select-String -Path $filePath -Pattern 'Out-Null' -AllMatches | ForEach-Object {
@@ -157,9 +160,10 @@ Describe 'PSModule - SourceCode tests' {
             $scriptFiles | ForEach-Object {
                 $filePath = $_.FullName
                 $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
-                $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
-                if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'NoTernary') {
-                    Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
+                $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:NoTernary:(?<Reason>.+)' -AllMatches
+                if ($skipTest.Matches.Count -gt 0) {
+                    $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
+                    Write-Verbose " - $relativePath - $skipReason" -Verbose
                     continue
                 }
                 Select-String -Path $filePath -Pattern '(?<!\|)\s+\?\s' -AllMatches | ForEach-Object {
@@ -174,12 +178,12 @@ Describe 'PSModule - SourceCode tests' {
             $scriptFiles | ForEach-Object {
                 $filePath = $_.FullName
                 $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
-                $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
-                if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'LowercaseKeywords') {
-                    Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
+                $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:LowercaseKeywords:(?<Reason>.+)' -AllMatches
+                if ($skipTest.Matches.Count -gt 0) {
+                    $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
+                    Write-Verbose " - $relativePath - $skipReason" -Verbose
                     continue
                 }
-
                 $errors = $null
                 $tokens = $null
                 [System.Management.Automation.Language.Parser]::ParseFile($FilePath, [ref]$tokens, [ref]$errors)
@@ -230,9 +234,10 @@ Describe 'PSModule - SourceCode tests' {
                 $functionBearingFiles | ForEach-Object {
                     $filePath = $_.FullName
                     $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
-                    $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
-                    if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'FunctionCount') {
-                        Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
+                    $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:FunctionCount:(?<Reason>.+)' -AllMatches
+                    if ($skipTest.Matches.Count -gt 0) {
+                        $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
+                        Write-Verbose " - $relativePath - $skipReason" -Verbose
                         continue
                     }
                     $Ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
@@ -250,9 +255,10 @@ Describe 'PSModule - SourceCode tests' {
                     $filePath = $_.FullName
                     $fileName = $_.BaseName
                     $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
-                    $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
-                    if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'FunctionName') {
-                        Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
+                    $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:FunctionName:(?<Reason>.+)' -AllMatches
+                    if ($skipTest.Matches.Count -gt 0) {
+                        $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
+                        Write-Verbose " - $relativePath - $skipReason" -Verbose
                         continue
                     }
                     $Ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
@@ -270,9 +276,10 @@ Describe 'PSModule - SourceCode tests' {
                     $found = $false
                     $filePath = $_.FullName
                     $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
-                    $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
-                    if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'CmdletBinding') {
-                        Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
+                    $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:CmdletBinding:(?<Reason>.+)' -AllMatches
+                    if ($skipTest.Matches.Count -gt 0) {
+                        $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
+                        Write-Verbose " - $relativePath - $skipReason" -Verbose
                         continue
                     }
                     $scriptAst = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
@@ -295,9 +302,10 @@ Describe 'PSModule - SourceCode tests' {
                     $found = $false
                     $filePath = $_.FullName
                     $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
-                    $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
-                    if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'ParamBlock') {
-                        Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
+                    $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:ParamBlock:(?<Reason>.+)' -AllMatches
+                    if ($skipTest.Matches.Count -gt 0) {
+                        $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
+                        Write-Verbose " - $relativePath - $skipReason" -Verbose
                         continue
                     }
                     $scriptAst = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
@@ -346,10 +354,10 @@ Describe 'PSModule - SourceCode tests' {
                 $functionBearingPublicFiles | ForEach-Object {
                     $filePath = $_.FullName
                     $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
-                    $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)'
-                    $skipTest | Out-String -Stream | ForEach-Object { Write-Verbose $_ -Verbose }
-                    if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'FunctionTest') {
-                        Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
+                    $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:FunctionTest:(?<Reason>.+)' -AllMatches
+                    if ($skipTest.Matches.Count -gt 0) {
+                        $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
+                        Write-Verbose " - $relativePath - $skipReason" -Verbose
                         continue
                     }
                     $Ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -22,6 +22,7 @@ BeforeAll {
     }
     $functionsPath = Join-Path -Path $Path -ChildPath 'functions'
     $functionFiles = (Test-Path -Path $functionsPath) ? (Get-ChildItem -Path $functionsPath -File -Filter '*.ps1' -Recurse) : $null
+
     LogGroup "Found $($functionFiles.Count) function files in [$functionsPath]" {
         $functionFiles | ForEach-Object {
             Write-Verbose " - $($_.FullName)" -Verbose
@@ -91,88 +92,24 @@ BeforeAll {
 }
 
 Describe 'PSModule - SourceCode tests' {
-    Context 'function/filter' {
-        It 'Should contain one function or filter (ID: FunctionCount)' {
+    Context 'General tests' {
+        It "Should use '[System.Environment]::ProcessorCount' instead of '`$env:NUMBER_OF_PROCESSORS' (ID: NumberOfProcessors)" {
             $issues = @('')
-            $functionFiles | ForEach-Object {
-                $filePath = $_.FullName
-                $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
-                $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
-                if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'FunctionCount') {
-                    Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
-                    continue
-                }
-                $Ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
-                $tokens = $Ast.FindAll( { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] } , $true )
-                if ($tokens.count -ne 1) {
-                    $issues += " - $relativePath - $($tokens.Name)"
+            $scriptFiles | ForEach-Object {
+                Select-String -Path $_.FullName -Pattern '\$env:NUMBER_OF_PROCESSORS' -AllMatches | ForEach-Object {
+                    $filePath = $_.FullName
+                    $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
+                    $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
+                    if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'NumberOfProcessors') {
+                        Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
+                        continue
+                    }
+                    $issues += " - $($_.Path):L$($_.LineNumber)"
                 }
             }
             $issues -join [Environment]::NewLine |
-                Should -BeNullOrEmpty -Because 'the script should contain one function or filter'
+                Should -BeNullOrEmpty -Because 'the script should use [System.Environment]::ProcessorCount instead of $env:NUMBER_OF_PROCESSORS'
         }
-
-        It 'Should have matching filename and function/filter name (ID: FunctionName)' {
-            $issues = @('')
-            $functionFiles | ForEach-Object {
-                $filePath = $_.FullName
-                $fileName = $_.BaseName
-                $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
-                $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
-                if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'FunctionName') {
-                    Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
-                    continue
-                }
-                $Ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
-                $tokens = $Ast.FindAll( { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] } , $true )
-                if ($tokens.Name -ne $fileName) {
-                    $issues += " - $relativePath - $($tokens.Name)"
-                }
-            }
-            $issues -join [Environment]::NewLine |
-                Should -BeNullOrEmpty -Because 'the script files should be called the same as the function they contain'
-        }
-
-        It 'All public functions/filters have tests (ID: FunctionTest)' {
-            $issues = @('')
-
-            # Get commands used in tests from the files in 'tests' folder.
-            $testFiles = Get-ChildItem -Path $TestsPath -Recurse -File -Filter '*.ps1'
-            $functionsInTestFiles = $testFiles | ForEach-Object {
-                $ast = [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$null, [ref]$null)
-                $ast.FindAll(
-                    {
-                        param($node)
-                        $node -is [System.Management.Automation.Language.CommandAst] -and
-                        $node.GetCommandName() -ne $null
-                    },
-                    $true
-                ) | ForEach-Object {
-                    $_.GetCommandName()
-                } | Sort-Object -Unique
-            }
-
-            # Get all the functions in the public function files and check if they have a test.
-            $publicFunctionFiles | ForEach-Object {
-                $filePath = $_.FullName
-                $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
-                $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
-                if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'FunctionTest') {
-                    Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
-                    continue
-                }
-                $Ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
-                $tokens = $Ast.FindAll( { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] } , $true )
-                $functionName = $tokens.Name
-                # If the file contains a function and the function name is not in the test files, add it as an issue.
-                if ($functionName.count -eq 1 -and $functionsInTestFiles -notcontains $functionName) {
-                    $issues += " - $relativePath - $functionName"
-                }
-            }
-            $issues -join [Environment]::NewLine |
-                Should -BeNullOrEmpty -Because 'a test should exist for each of the functions in the module'
-        }
-
         It "Should not contain '-Verbose' unless it is disabled using ':`$false' qualifier after it (ID: Verbose)" {
             $issues = @('')
             $scriptFiles | ForEach-Object {
@@ -190,7 +127,6 @@ Describe 'PSModule - SourceCode tests' {
             $issues -join [Environment]::NewLine |
                 Should -BeNullOrEmpty -Because "the script should not contain '-Verbose' unless it is disabled using ':`$false' qualifier after it."
         }
-
         It "Should use '`$null = ...' instead of '... | Out-Null' (ID: OutNull)" {
             $issues = @('')
             $scriptFiles | ForEach-Object {
@@ -208,7 +144,6 @@ Describe 'PSModule - SourceCode tests' {
             $issues -join [Environment]::NewLine |
                 Should -BeNullOrEmpty -Because "the script should use '`$null = ...' instead of '... | Out-Null'"
         }
-
         It 'Should not use ternary operations for compatability reasons (ID: NoTernary)' -Skip {
             $issues = @('')
             $scriptFiles | ForEach-Object {
@@ -226,7 +161,6 @@ Describe 'PSModule - SourceCode tests' {
             $issues -join [Environment]::NewLine |
                 Should -BeNullOrEmpty -Because 'the script should not use ternary operations for compatability with PS 5.1 and below'
         }
-
         It 'all powershell keywords are lowercase (ID: LowercaseKeywords)' {
             $issues = @('')
             $scriptFiles | ForEach-Object {
@@ -253,99 +187,163 @@ Describe 'PSModule - SourceCode tests' {
             }
             $issues -join [Environment]::NewLine | Should -BeNullOrEmpty -Because 'all powershell keywords should be lowercase'
         }
-
-        # It 'comment based doc block start is indented with 4 spaces' {}
-        # It 'comment based doc is indented with 8 spaces' {}
-        # It 'has synopsis for all functions' {}
-        # It 'has description for all functions' {}
-        # It 'has examples for all functions' {}
-
-        It 'Should have [CmdletBinding()] attribute (ID: CmdletBinding)' {
-            $issues = @('')
-            $functionFiles | ForEach-Object {
-                $found = $false
-                $filePath = $_.FullName
-                $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
-                $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
-                if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'CmdletBinding') {
-                    Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
-                    continue
-                }
-                $scriptAst = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
-                $tokens = $scriptAst.FindAll({ $true }, $true)
-                foreach ($token in $tokens) {
-                    if ($token.TypeName.Name -eq 'CmdletBinding') {
-                        $found = $true
-                    }
-                }
-                if (-not $found) {
-                    $issues += " - $relativePath"
-                }
-            }
-            $issues -join [Environment]::NewLine |
-                Should -BeNullOrEmpty -Because 'the script should have [CmdletBinding()] attribute'
-        }
-
-        It 'Should have a param() block (ID: ParamBlock)' {
-            $issues = @('')
-            $functionFiles | ForEach-Object {
-                $found = $false
-                $filePath = $_.FullName
-                $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
-                $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
-                if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'ParamBlock') {
-                    Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
-                    continue
-                }
-                $scriptAst = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
-                $tokens = $scriptAst.FindAll({ $args[0] -is [System.Management.Automation.Language.ParamBlockAst] }, $true)
-                foreach ($token in $tokens) {
-                    if ($token.count -eq 1) {
-                        $found = $true
-                    }
-                }
-                if (-not $found) {
-                    $issues += " - $relativePath"
-                }
-            }
-            $issues -join [Environment]::NewLine |
-                Should -BeNullOrEmpty -Because 'the script should have a param() block'
-        }
-
-        # It 'boolean parameters in CmdletBinding() attribute are written without assignments' {}
-        #     I.e. [CmdletBinding(ShouldProcess)] instead of [CmdletBinding(ShouldProcess = $true)]
-        # It 'has [OutputType()] attribute' {}
     }
 
-    Context 'Parameter design' {
-        # It 'has parameter description for all functions' {}
-        # It 'parameters have [Parameter()] attribute' {}
-        # It 'boolean parameters to the [Parameter()] attribute are written without assignments' {}
-        #     I.e. [Parameter(Mandatory)] instead of [Parameter(Mandatory = $true)]
-        # It 'datatype for parameters are written on the same line as the parameter name' {}
-        # It 'datatype for parameters and parameter name are separated by a single space' {}
-        # It 'parameters are separated by a blank line' {}
-    }
+    Context 'classes' {}
 
-    Context 'Compatability checks' {
-        It "Should use '[System.Environment]::ProcessorCount' instead of '`$env:NUMBER_OF_PROCESSORS' (ID: NumberOfProcessors)" {
-            $issues = @('')
-            $scriptFiles | ForEach-Object {
-                Select-String -Path $_.FullName -Pattern '\$env:NUMBER_OF_PROCESSORS' -AllMatches | ForEach-Object {
+    Context 'functions' {
+        Context 'Generic' {
+            # It 'has synopsis for all functions' {}
+            # It 'has description for all functions' {}
+            # It 'has examples for all functions' {}
+            # It 'comment based doc is indented with 8 spaces' {}
+            # It 'boolean parameters in CmdletBinding() attribute are written without assignments' {}
+            #     I.e. [CmdletBinding(ShouldProcess)] instead of [CmdletBinding(ShouldProcess = $true)]
+            # It 'has [OutputType()] attribute' {}
+            # Parameters
+            # It 'comment based doc block start is indented with 4 spaces' {}
+            # It 'has parameter description for all functions' {}
+            # It 'parameters have [Parameter()] attribute' {}
+            # It 'boolean parameters to the [Parameter()] attribute are written without assignments' {}
+            #     I.e. [Parameter(Mandatory)] instead of [Parameter(Mandatory = $true)]
+            # It 'datatype for parameters are written on the same line as the parameter name' {}
+            # It 'datatype for parameters and parameter name are separated by a single space' {}
+            # It 'parameters are separated by a blank line' {}
+            It 'Should contain one function or filter (ID: FunctionCount)' {
+                $issues = @('')
+                $functionFiles | ForEach-Object {
                     $filePath = $_.FullName
                     $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
                     $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
-                    if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'NumberOfProcessors') {
+                    if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'FunctionCount') {
                         Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
                         continue
                     }
-                    $issues += " - $($_.Path):L$($_.LineNumber)"
+                    $Ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
+                    $tokens = $Ast.FindAll( { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] } , $true )
+                    if ($tokens.count -ne 1) {
+                        $issues += " - $relativePath - $($tokens.Name)"
+                    }
                 }
+                $issues -join [Environment]::NewLine |
+                    Should -BeNullOrEmpty -Because 'the script should contain one function or filter'
             }
-            $issues -join [Environment]::NewLine |
-                Should -BeNullOrEmpty -Because 'the script should use [System.Environment]::ProcessorCount instead of $env:NUMBER_OF_PROCESSORS'
+            It 'Should have matching filename and function/filter name (ID: FunctionName)' {
+                $issues = @('')
+                $functionFiles | ForEach-Object {
+                    $filePath = $_.FullName
+                    $fileName = $_.BaseName
+                    $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
+                    $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
+                    if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'FunctionName') {
+                        Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
+                        continue
+                    }
+                    $Ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
+                    $tokens = $Ast.FindAll( { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] } , $true )
+                    if ($tokens.Name -ne $fileName) {
+                        $issues += " - $relativePath - $($tokens.Name)"
+                    }
+                }
+                $issues -join [Environment]::NewLine |
+                    Should -BeNullOrEmpty -Because 'the script files should be called the same as the function they contain'
+            }
+            It 'Should have [CmdletBinding()] attribute (ID: CmdletBinding)' {
+                $issues = @('')
+                $functionFiles | ForEach-Object {
+                    $found = $false
+                    $filePath = $_.FullName
+                    $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
+                    $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
+                    if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'CmdletBinding') {
+                        Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
+                        continue
+                    }
+                    $scriptAst = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
+                    $tokens = $scriptAst.FindAll({ $true }, $true)
+                    foreach ($token in $tokens) {
+                        if ($token.TypeName.Name -eq 'CmdletBinding') {
+                            $found = $true
+                        }
+                    }
+                    if (-not $found) {
+                        $issues += " - $relativePath"
+                    }
+                }
+                $issues -join [Environment]::NewLine |
+                    Should -BeNullOrEmpty -Because 'the script should have [CmdletBinding()] attribute'
+            }
+            It 'Should have a param() block (ID: ParamBlock)' {
+                $issues = @('')
+                $functionFiles | ForEach-Object {
+                    $found = $false
+                    $filePath = $_.FullName
+                    $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
+                    $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
+                    if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'ParamBlock') {
+                        Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
+                        continue
+                    }
+                    $scriptAst = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
+                    $tokens = $scriptAst.FindAll({ $args[0] -is [System.Management.Automation.Language.ParamBlockAst] }, $true)
+                    foreach ($token in $tokens) {
+                        if ($token.count -eq 1) {
+                            $found = $true
+                        }
+                    }
+                    if (-not $found) {
+                        $issues += " - $relativePath"
+                    }
+                }
+                $issues -join [Environment]::NewLine |
+                    Should -BeNullOrEmpty -Because 'the script should have a param() block'
+            }
         }
+        Context 'public functions' {
+            It 'All public functions/filters have tests (ID: FunctionTest)' {
+                $issues = @('')
+
+                # Get commands used in tests from the files in 'tests' folder.
+                $testFiles = Get-ChildItem -Path $TestsPath -Recurse -File -Filter '*.ps1'
+                $functionsInTestFiles = $testFiles | ForEach-Object {
+                    $ast = [System.Management.Automation.Language.Parser]::ParseFile($_.FullName, [ref]$null, [ref]$null)
+                    $ast.FindAll(
+                        {
+                            param($node)
+                            $node -is [System.Management.Automation.Language.CommandAst] -and
+                            $node.GetCommandName() -ne $null
+                        },
+                        $true
+                    ) | ForEach-Object {
+                        $_.GetCommandName()
+                    } | Sort-Object -Unique
+                }
+
+                # Get all the functions in the public function files and check if they have a test.
+                $publicFunctionFiles | ForEach-Object {
+                    $filePath = $_.FullName
+                    $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
+                    $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
+                    if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'FunctionTest') {
+                        Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
+                        continue
+                    }
+                    $Ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
+                    $tokens = $Ast.FindAll( { $args[0] -is [System.Management.Automation.Language.FunctionDefinitionAst] } , $true )
+                    $functionName = $tokens.Name
+                    # If the file contains a function and the function name is not in the test files, add it as an issue.
+                    if ($functionName.count -eq 1 -and $functionsInTestFiles -notcontains $functionName) {
+                        $issues += " - $relativePath - $functionName"
+                    }
+                }
+                $issues -join [Environment]::NewLine |
+                    Should -BeNullOrEmpty -Because 'a test should exist for each of the functions in the module'
+            }
+        }
+        Context 'private functions' {}
     }
+
+    Context 'variables' {}
 
     Context 'Module manifest' {
         # It 'Module Manifest exists (maifest.psd1 or modulename.psd1)' {}

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -21,7 +21,7 @@ BeforeAll {
         }
     }
     $functionsPath = Join-Path -Path $Path -ChildPath 'functions'
-    $functionFiles = (Test-Path -Path $functionsPath) ? (Get-ChildItem -Path $functionsPath -Filter '*.ps1' -File) : $null
+    $functionFiles = (Test-Path -Path $functionsPath) ? (Get-ChildItem -Path $functionsPath -File -Filter '*.ps1' -Recurse) : $null
     LogGroup "Found $($functionFiles.Count) function files in [$functionsPath]" {
         $functionFiles | ForEach-Object {
             Write-Verbose " - $($_.FullName)" -Verbose

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -123,7 +123,7 @@ Describe 'PSModule - SourceCode tests' {
                 Should -BeNullOrEmpty -Because "the script should use '`$null = ...' instead of '... | Out-Null'"
         }
 
-        It 'Should not use ternary operations for compatability reasons' {
+        It 'Should not use ternary operations for compatability reasons' -Skip {
             $issues = @('')
             $scriptFiles | ForEach-Object {
                 $filePath = $_.FullName

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -17,14 +17,14 @@ BeforeAll {
     $scriptFiles = Get-ChildItem -Path $Path -Include *.psm1, *.ps1 -Recurse -File
     LogGroup "Found $($scriptFiles.Count) script files in [$Path]" {
         $scriptFiles | ForEach-Object {
-            Write-Verbose " - $($_.FullName)"
+            Write-Verbose " - $($_.FullName)" -Verbose
         }
     }
     $functionsPath = Join-Path -Path $Path -ChildPath 'functions'
     $functionFiles = (Test-Path -Path $functionsPath) ? (Get-ChildItem -Path $functionsPath -Filter '*.ps1' -File) : $null
     LogGroup "Found $($functionFiles.Count) function files in [$functionsPath]" {
         $functionFiles | ForEach-Object {
-            Write-Verbose " - $($_.FullName)"
+            Write-Verbose " - $($_.FullName)" -Verbose
         }
     }
     $privateFunctionsPath = Join-Path -Path $functionsPath -ChildPath 'private'
@@ -32,21 +32,21 @@ BeforeAll {
         (Get-ChildItem -Path $privateFunctionsPath -File -Filter '*.ps1' -Recurse) : $null
     LogGroup "Found $($privateFunctionFiles.Count) private function files in [$privateFunctionsPath]" {
         $privateFunctionFiles | ForEach-Object {
-            Write-Verbose " - $($_.FullName)"
+            Write-Verbose " - $($_.FullName)" -Verbose
         }
     }
     $publicFunctionsPath = Join-Path -Path $functionsPath -ChildPath 'public'
     $publicFunctionFiles = (Test-Path -Path $publicFunctionsPath) ? (Get-ChildItem -Path $publicFunctionsPath -File -Filter '*.ps1' -Recurse) : $null
     LogGroup "Found $($publicFunctionFiles.Count) public function files in [$publicFunctionsPath]" {
         $publicFunctionFiles | ForEach-Object {
-            Write-Verbose " - $($_.FullName)"
+            Write-Verbose " - $($_.FullName)" -Verbose
         }
     }
     $variablesPath = Join-Path -Path $Path -ChildPath 'variables'
     $variableFiles = (Test-Path -Path $variablesPath) ? (Get-ChildItem -Path $variablesPath -File -Filter '*.ps1' -Recurse) : $null
     LogGroup "Found $($variableFiles.Count) variable files in [$variablesPath]" {
         $variableFiles | ForEach-Object {
-            Write-Verbose " - $($_.FullName)"
+            Write-Verbose " - $($_.FullName)" -Verbose
         }
     }
     $privateVariablesPath = Join-Path -Path $variablesPath -ChildPath 'private'
@@ -54,7 +54,7 @@ BeforeAll {
         (Get-ChildItem -Path $privateVariablesPath -File -Filter '*.ps1' -Recurse) : $null
     LogGroup "Found $($privateVariableFiles.Count) private variable files in [$privateVariablesPath]" {
         $privateVariableFiles | ForEach-Object {
-            Write-Verbose " - $($_.FullName)"
+            Write-Verbose " - $($_.FullName)" -Verbose
         }
     }
     $publicVariablesPath = Join-Path -Path $variablesPath -ChildPath 'public'
@@ -62,14 +62,14 @@ BeforeAll {
         (Get-ChildItem -Path $publicVariablesPath -File -Filter '*.ps1' -Recurse) : $null
     LogGroup "Found $($publicVariableFiles.Count) public variable files in [$publicVariablesPath]" {
         $publicVariableFiles | ForEach-Object {
-            Write-Verbose " - $($_.FullName)"
+            Write-Verbose " - $($_.FullName)" -Verbose
         }
     }
     $classPath = Join-Path -Path $Path -ChildPath 'classes'
     $classFiles = (Test-Path -Path $classPath) ? (Get-ChildItem -Path $classPath -File -Filter '*.ps1' -Recurse) : $null
     LogGroup "Found $($classFiles.Count) class files in [$classPath]" {
         $classFiles | ForEach-Object {
-            Write-Verbose " - $($_.FullName)"
+            Write-Verbose " - $($_.FullName)" -Verbose
         }
     }
     $privateClassPath = Join-Path -Path $classPath -ChildPath 'private'
@@ -77,7 +77,7 @@ BeforeAll {
         (Get-ChildItem -Path $privateClassPath -File -Filter '*.ps1' -Recurse) : $null
     LogGroup "Found $($privateClassFiles.Count) private class files in [$privateClassPath]" {
         $privateClassFiles | ForEach-Object {
-            Write-Verbose " - $($_.FullName)"
+            Write-Verbose " - $($_.FullName)" -Verbose
         }
     }
     $publicClassPath = Join-Path -Path $classPath -ChildPath 'public'
@@ -85,7 +85,7 @@ BeforeAll {
         (Get-ChildItem -Path $publicClassPath -File -Filter '*.ps1' -Recurse) : $null
     LogGroup "Found $($publicClassFiles.Count) public class files in [$publicClassPath]" {
         $publicClassFiles | ForEach-Object {
-            Write-Verbose " - $($_.FullName)"
+            Write-Verbose " - $($_.FullName)" -Verbose
         }
     }
 }

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -110,7 +110,7 @@ Describe 'PSModule - SourceCode tests' {
                     $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:NumberOfProcessors:(?<Reason>.+)' -AllMatches
                     if ($skipTest.Matches.Count -gt 0) {
                         $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                        Write-GitHubWarning " - $relativePath - $skipReason"
+                        Write-GitHubWarning -Message " - $relativePath - $skipReason" -Title 'Skipping NumberOfProcessors test'
                         continue
                     }
                     $issues += " - $($_.Path):L$($_.LineNumber)"
@@ -127,7 +127,7 @@ Describe 'PSModule - SourceCode tests' {
                 $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:Verbose:(?<Reason>.+)' -AllMatches
                 if ($skipTest.Matches.Count -gt 0) {
                     $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                    Write-GitHubWarning " - $relativePath - $skipReason"
+                    Write-GitHubWarning -Message " - $relativePath - $skipReason" -Title 'Skipping Verbose test'
                     continue
                 }
                 Select-String -Path $filePath -Pattern '\s(-Verbose(?::\$true)?)\b(?!:\$false)' -AllMatches | ForEach-Object {
@@ -145,7 +145,7 @@ Describe 'PSModule - SourceCode tests' {
                 $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:OutNull:(?<Reason>.+)' -AllMatches
                 if ($skipTest.Matches.Count -gt 0) {
                     $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                    Write-GitHubWarning " - $relativePath - $skipReason"
+                    Write-GitHubWarning -Message " - $relativePath - $skipReason" -Title 'Skipping OutNull test'
                     continue
                 }
                 Select-String -Path $filePath -Pattern 'Out-Null' -AllMatches | ForEach-Object {
@@ -163,7 +163,7 @@ Describe 'PSModule - SourceCode tests' {
                 $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:NoTernary:(?<Reason>.+)' -AllMatches
                 if ($skipTest.Matches.Count -gt 0) {
                     $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                    Write-GitHubWarning " - $relativePath - $skipReason"
+                    Write-GitHubWarning -Message " - $relativePath - $skipReason" -Title 'Skipping NoTernary test'
                     continue
                 }
                 Select-String -Path $filePath -Pattern '(?<!\|)\s+\?\s' -AllMatches | ForEach-Object {
@@ -181,7 +181,7 @@ Describe 'PSModule - SourceCode tests' {
                 $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:LowercaseKeywords:(?<Reason>.+)' -AllMatches
                 if ($skipTest.Matches.Count -gt 0) {
                     $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                    Write-GitHubWarning " - $relativePath - $skipReason"
+                    Write-GitHubWarning -Message " - $relativePath - $skipReason" -Title 'Skipping LowercaseKeywords test'
                     continue
                 }
                 $errors = $null
@@ -237,7 +237,7 @@ Describe 'PSModule - SourceCode tests' {
                     $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:FunctionCount:(?<Reason>.+)' -AllMatches
                     if ($skipTest.Matches.Count -gt 0) {
                         $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                        Write-GitHubWarning " - $relativePath - $skipReason"
+                        Write-GitHubWarning -Message " - $relativePath - $skipReason" -Title 'Skipping FunctionCount test'
                         continue
                     }
                     $Ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
@@ -258,7 +258,7 @@ Describe 'PSModule - SourceCode tests' {
                     $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:FunctionName:(?<Reason>.+)' -AllMatches
                     if ($skipTest.Matches.Count -gt 0) {
                         $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                        Write-GitHubWarning " - $relativePath - $skipReason"
+                        Write-GitHubWarning -Message " - $relativePath - $skipReason" -Title 'Skipping FunctionName test'
                         continue
                     }
                     $Ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
@@ -279,7 +279,7 @@ Describe 'PSModule - SourceCode tests' {
                     $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:CmdletBinding:(?<Reason>.+)' -AllMatches
                     if ($skipTest.Matches.Count -gt 0) {
                         $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                        Write-GitHubWarning " - $relativePath - $skipReason"
+                        Write-GitHubWarning -Message " - $relativePath - $skipReason" -Title 'Skipping CmdletBinding test'
                         continue
                     }
                     $scriptAst = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
@@ -305,7 +305,7 @@ Describe 'PSModule - SourceCode tests' {
                     $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:ParamBlock:(?<Reason>.+)' -AllMatches
                     if ($skipTest.Matches.Count -gt 0) {
                         $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                        Write-GitHubWarning " - $relativePath - $skipReason"
+                        Write-GitHubWarning -Message " - $relativePath - $skipReason" -Title 'Skipping ParamBlock test'
                         continue
                     }
                     $scriptAst = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
@@ -357,7 +357,7 @@ Describe 'PSModule - SourceCode tests' {
                     $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:FunctionTest:(?<Reason>.+)' -AllMatches
                     if ($skipTest.Matches.Count -gt 0) {
                         $skipReason = $skipTest.Matches.Groups | Where-Object { $_.Name -eq 'Reason' } | Select-Object -ExpandProperty Value
-                        Write-GitHubWarning " - $relativePath - $skipReason"
+                        Write-GitHubWarning -Message " - $relativePath - $skipReason" -Title 'Skipping FunctionTest test'
                         continue
                     }
                     $Ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -1,35 +1,93 @@
-﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
     'PSReviewUnusedParameter', '',
     Justification = 'Parameters are used in the test.'
 )]
 [CmdLetBinding()]
 Param(
+    # The path to the 'src' folder of the repo.
     [Parameter(Mandatory)]
     [string] $Path,
 
+    # The path to the 'tests' folder of the repo.
     [Parameter(Mandatory)]
     [string] $TestsPath
 )
 
 BeforeAll {
     $scriptFiles = Get-ChildItem -Path $Path -Include *.psm1, *.ps1 -Recurse -File
-    LogGroup 'Script files:' {
+    LogGroup "Found $($scriptFiles.Count) script files in [$Path]" {
         $scriptFiles | ForEach-Object {
             Write-Verbose " - $($_.FullName)"
         }
     }
     $functionsPath = Join-Path -Path $Path -ChildPath 'functions'
-    # $privateFunctionsPath = Join-Path -Path $functionsPath -ChildPath 'private'
-    $publicFunctionsPath = Join-Path -Path $functionsPath -ChildPath 'public'
-    # $variablesPath = Join-Path -Path $Path -ChildPath 'variables'
-    # $privateVariablesPath = Join-Path -Path $variablesPath -ChildPath 'private'
-    # $publicVariablesPath = Join-Path -Path $variablesPath -ChildPath 'public'
     $functionFiles = (Test-Path -Path $functionsPath) ? (Get-ChildItem -Path $functionsPath -Filter '*.ps1' -File) : $null
+    LogGroup "Found $($functionFiles.Count) function files in [$functionsPath]" {
+        $functionFiles | ForEach-Object {
+            Write-Verbose " - $($_.FullName)"
+        }
+    }
+    $privateFunctionsPath = Join-Path -Path $functionsPath -ChildPath 'private'
+    $privateFunctionFiles = (Test-Path -Path $privateFunctionsPath) ?
+        (Get-ChildItem -Path $privateFunctionsPath -File -Filter '*.ps1' -Recurse) : $null
+    LogGroup "Found $($privateFunctionFiles.Count) private function files in [$privateFunctionsPath]" {
+        $privateFunctionFiles | ForEach-Object {
+            Write-Verbose " - $($_.FullName)"
+        }
+    }
+    $publicFunctionsPath = Join-Path -Path $functionsPath -ChildPath 'public'
     $publicFunctionFiles = (Test-Path -Path $publicFunctionsPath) ? (Get-ChildItem -Path $publicFunctionsPath -File -Filter '*.ps1' -Recurse) : $null
-
-    Write-Verbose "Found $($scriptFiles.Count) script files in [$Path]"
-    Write-Verbose "Found $($functionFiles.Count) function files in [$functionsPath]"
-    Write-Verbose "Found $($publicFunctionFiles.Count) public function files in [$publicFunctionsPath]"
+    LogGroup "Found $($publicFunctionFiles.Count) public function files in [$publicFunctionsPath]" {
+        $publicFunctionFiles | ForEach-Object {
+            Write-Verbose " - $($_.FullName)"
+        }
+    }
+    $variablesPath = Join-Path -Path $Path -ChildPath 'variables'
+    $variableFiles = (Test-Path -Path $variablesPath) ? (Get-ChildItem -Path $variablesPath -File -Filter '*.ps1' -Recurse) : $null
+    LogGroup "Found $($variableFiles.Count) variable files in [$variablesPath]" {
+        $variableFiles | ForEach-Object {
+            Write-Verbose " - $($_.FullName)"
+        }
+    }
+    $privateVariablesPath = Join-Path -Path $variablesPath -ChildPath 'private'
+    $privateVariableFiles = (Test-Path -Path $privateVariablesPath) ?
+        (Get-ChildItem -Path $privateVariablesPath -File -Filter '*.ps1' -Recurse) : $null
+    LogGroup "Found $($privateVariableFiles.Count) private variable files in [$privateVariablesPath]" {
+        $privateVariableFiles | ForEach-Object {
+            Write-Verbose " - $($_.FullName)"
+        }
+    }
+    $publicVariablesPath = Join-Path -Path $variablesPath -ChildPath 'public'
+    $publicVariableFiles = (Test-Path -Path $publicVariablesPath) ?
+        (Get-ChildItem -Path $publicVariablesPath -File -Filter '*.ps1' -Recurse) : $null
+    LogGroup "Found $($publicVariableFiles.Count) public variable files in [$publicVariablesPath]" {
+        $publicVariableFiles | ForEach-Object {
+            Write-Verbose " - $($_.FullName)"
+        }
+    }
+    $classPath = Join-Path -Path $Path -ChildPath 'classes'
+    $classFiles = (Test-Path -Path $classPath) ? (Get-ChildItem -Path $classPath -File -Filter '*.ps1' -Recurse) : $null
+    LogGroup "Found $($classFiles.Count) class files in [$classPath]" {
+        $classFiles | ForEach-Object {
+            Write-Verbose " - $($_.FullName)"
+        }
+    }
+    $privateClassPath = Join-Path -Path $classPath -ChildPath 'private'
+    $privateClassFiles = (Test-Path -Path $privateClassPath) ?
+        (Get-ChildItem -Path $privateClassPath -File -Filter '*.ps1' -Recurse) : $null
+    LogGroup "Found $($privateClassFiles.Count) private class files in [$privateClassPath]" {
+        $privateClassFiles | ForEach-Object {
+            Write-Verbose " - $($_.FullName)"
+        }
+    }
+    $publicClassPath = Join-Path -Path $classPath -ChildPath 'public'
+    $publicClassFiles = (Test-Path -Path $publicClassPath) ?
+        (Get-ChildItem -Path $publicClassPath -File -Filter '*.ps1' -Recurse) : $null
+    LogGroup "Found $($publicClassFiles.Count) public class files in [$publicClassPath]" {
+        $publicClassFiles | ForEach-Object {
+            Write-Verbose " - $($_.FullName)"
+        }
+    }
 }
 
 Describe 'PSModule - SourceCode tests' {

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -346,7 +346,7 @@ Describe 'PSModule - SourceCode tests' {
                 $functionBearingPublicFiles | ForEach-Object {
                     $filePath = $_.FullName
                     $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
-                    $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
+                    $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)'
                     $skipTest | Out-String -Stream | ForEach-Object { Write-Verbose $_ -Verbose }
                     if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'FunctionTest') {
                         Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -347,6 +347,7 @@ Describe 'PSModule - SourceCode tests' {
                     $filePath = $_.FullName
                     $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
                     $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
+                    $skipTest | Out-String -Stream | ForEach-Object { Write-Verbose $_ -Verbose }
                     if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'FunctionTest') {
                         Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
                         continue

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -99,7 +99,7 @@ Describe 'PSModule - SourceCode tests' {
                 $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
                 $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
                 if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'FunctionCount') {
-                    Write-Warning " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)"
+                    Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
                     continue
                 }
                 $Ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
@@ -120,7 +120,7 @@ Describe 'PSModule - SourceCode tests' {
                 $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
                 $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
                 if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'FunctionName') {
-                    Write-Warning " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)"
+                    Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
                     continue
                 }
                 $Ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
@@ -158,7 +158,7 @@ Describe 'PSModule - SourceCode tests' {
                 $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
                 $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
                 if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'FunctionTest') {
-                    Write-Warning " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)"
+                    Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
                     continue
                 }
                 $Ast = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
@@ -180,7 +180,7 @@ Describe 'PSModule - SourceCode tests' {
                 $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
                 $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
                 if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'Verbose') {
-                    Write-Warning " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)"
+                    Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
                     continue
                 }
                 Select-String -Path $filePath -Pattern '\s(-Verbose(?::\$true)?)\b(?!:\$false)' -AllMatches | ForEach-Object {
@@ -198,7 +198,7 @@ Describe 'PSModule - SourceCode tests' {
                 $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
                 $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
                 if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'OutNull') {
-                    Write-Warning " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)"
+                    Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
                     continue
                 }
                 Select-String -Path $filePath -Pattern 'Out-Null' -AllMatches | ForEach-Object {
@@ -216,7 +216,7 @@ Describe 'PSModule - SourceCode tests' {
                 $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
                 $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
                 if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'NoTernary') {
-                    Write-Warning " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)"
+                    Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
                     continue
                 }
                 Select-String -Path $filePath -Pattern '(?<!\|)\s+\?\s' -AllMatches | ForEach-Object {
@@ -234,7 +234,7 @@ Describe 'PSModule - SourceCode tests' {
                 $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
                 $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
                 if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'LowercaseKeywords') {
-                    Write-Warning " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)"
+                    Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
                     continue
                 }
 
@@ -268,7 +268,7 @@ Describe 'PSModule - SourceCode tests' {
                 $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
                 $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
                 if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'CmdletBinding') {
-                    Write-Warning " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)"
+                    Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
                     continue
                 }
                 $scriptAst = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
@@ -294,7 +294,7 @@ Describe 'PSModule - SourceCode tests' {
                 $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
                 $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
                 if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'ParamBlock') {
-                    Write-Warning " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)"
+                    Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
                     continue
                 }
                 $scriptAst = [System.Management.Automation.Language.Parser]::ParseFile($filePath, [ref]$null, [ref]$null)
@@ -336,7 +336,7 @@ Describe 'PSModule - SourceCode tests' {
                     $relativePath = $filePath.Replace($Path, '').Trim('\').Trim('/')
                     $skipTest = Select-String -Path $filePath -Pattern '#SkipTest:(?<Type>.+):(?<Reason>.+)' -AllMatches
                     if ($skipTest.Matches.Count -gt 0 -and $skipTest.Matches.Groups['Type'].Value -eq 'NumberOfProcessors') {
-                        Write-Warning " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)"
+                        Write-Verbose " - $relativePath - $($skipTest.Matches.Groups['Reason'].Value)" -Verbose
                         continue
                     }
                     $issues += " - $($_.Path):L$($_.LineNumber)"

--- a/scripts/tests/PSModule/SourceCode.Tests.ps1
+++ b/scripts/tests/PSModule/SourceCode.Tests.ps1
@@ -90,7 +90,6 @@ BeforeAll {
     }
 }
 
-
 Describe 'PSModule - SourceCode tests' {
     Context 'function/filter' {
         It 'Should contain one function or filter (ID: FunctionCount)' {

--- a/tests/src/functions/public/New-PSModuleTest.ps1
+++ b/tests/src/functions/public/New-PSModuleTest.ps1
@@ -1,5 +1,5 @@
 ﻿#Requires -Modules @{ModuleName='PSSemVer'; ModuleVersion='1.0'}
-
+#SkipTest:FunctionTest:Difficult to test due to the nature of the function.
 function New-PSModuleTest {
     <#
         .SYNOPSIS
@@ -33,6 +33,4 @@ function New-PSModuleTest {
 
 New-Alias New-PSModuleTestAlias3 New-PSModuleTest
 New-Alias -Name New-PSModuleTestAlias4 -Value New-PSModuleTest
-
-
 Set-Alias New-PSModuleTestAlias5 New-PSModuleTest

--- a/tests/src/functions/public/New-PSModuleTest.ps1
+++ b/tests/src/functions/public/New-PSModuleTest.ps1
@@ -1,5 +1,6 @@
 ﻿#Requires -Modules @{ModuleName='PSSemVer'; ModuleVersion='1.0'}
 #SkipTest:FunctionTest:Difficult to test due to the nature of the function.
+#SkipTest:Verbose:Just want to test that a function can have multiple skips.
 function New-PSModuleTest {
     <#
         .SYNOPSIS
@@ -28,6 +29,7 @@ function New-PSModuleTest {
         [string] $Name
     )
     Write-Debug "Debug message"
+    Write-Verbose "Verbose message" -Verbose
     Write-Output "Hello, $Name!"
 }
 

--- a/tests/src/functions/public/Test-PSModuleTest.ps1
+++ b/tests/src/functions/public/Test-PSModuleTest.ps1
@@ -1,4 +1,5 @@
-﻿function Test-PSModuleTest {
+﻿#SkipTest:Verbose:Just want to test that a function can have multiple skips.
+function Test-PSModuleTest {
     <#
         .SYNOPSIS
         Performs tests on a module.
@@ -15,4 +16,5 @@
         [string] $Name
     )
     Write-Output "Hello, $Name!"
+    Write-Verbose 'Verbose message' -Verbose
 }

--- a/tests/src/functions/public/completers.ps1
+++ b/tests/src/functions/public/completers.ps1
@@ -1,0 +1,8 @@
+﻿Register-ArgumentCompleter -CommandName New-PSModuleTest -ParameterName Name -ScriptBlock {
+    param($commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters)
+    $null = $commandName, $parameterName, $wordToComplete, $commandAst, $fakeBoundParameters
+
+    'Alice', 'Bob', 'Charlie' | Where-Object { $_ -like "$wordToComplete*" } | ForEach-Object {
+        [System.Management.Automation.CompletionResult]::new($_, $_, 'ParameterValue', $_)
+    }
+}

--- a/tests/srcWithManifest/functions/public/New-PSModuleTest.ps1
+++ b/tests/srcWithManifest/functions/public/New-PSModuleTest.ps1
@@ -1,5 +1,5 @@
 ﻿#Requires -Modules @{ModuleName='PSSemVer'; ModuleVersion='1.0'}
-
+#SkipTest:FunctionTest:Difficult to test due to the nature of the function.
 function New-PSModuleTest {
     <#
         .SYNOPSIS

--- a/tests/srcWithManifest/functions/public/New-PSModuleTest.ps1
+++ b/tests/srcWithManifest/functions/public/New-PSModuleTest.ps1
@@ -1,5 +1,6 @@
 ﻿#Requires -Modules @{ModuleName='PSSemVer'; ModuleVersion='1.0'}
 #SkipTest:FunctionTest:Difficult to test due to the nature of the function.
+#SkipTest:Verbose:Just want to test that a function can have multiple skips.
 function New-PSModuleTest {
     <#
         .SYNOPSIS
@@ -27,11 +28,11 @@ function New-PSModuleTest {
         [Parameter(Mandatory)]
         [string] $Name
     )
+    Write-Debug "Debug message"
+    Write-Verbose "Verbose message" -Verbose
     Write-Output "Hello, $Name!"
 }
 
 New-Alias New-PSModuleTestAlias3 New-PSModuleTest
 New-Alias -Name New-PSModuleTestAlias4 -Value New-PSModuleTest
-
-
 Set-Alias New-PSModuleTestAlias5 New-PSModuleTest

--- a/tests/srcWithManifest/functions/public/Test-PSModuleTest.ps1
+++ b/tests/srcWithManifest/functions/public/Test-PSModuleTest.ps1
@@ -1,4 +1,5 @@
-﻿function Test-PSModuleTest {
+﻿#SkipTest:Verbose:Just want to test that a function can have multiple skips.
+function Test-PSModuleTest {
     <#
         .SYNOPSIS
         Performs tests on a module.
@@ -15,4 +16,5 @@
         [string] $Name
     )
     Write-Output "Hello, $Name!"
+    Write-Verbose 'Verbose message' -Verbose
 }

--- a/tests/tests/PSModuleTest.Tests.ps1
+++ b/tests/tests/PSModuleTest.Tests.ps1
@@ -2,9 +2,6 @@
     It 'Function: Get-PSModuleTest' {
         Get-PSModuleTest -Name 'World' | Should -Be 'Hello, World!'
     }
-    It 'Function: New-PSModuleTest' {
-        New-PSModuleTest -Name 'World' | Should -Be 'Hello, World!'
-    }
     It 'Function: Set-PSModuleTest' {
         Set-PSModuleTest -Name 'World' | Should -Be 'Hello, World!'
     }


### PR DESCRIPTION
## Description

- Implements a inline way to skip tests on source code tests.
  - Fixes #73
- Allow to hold completers in the `src/functions/public` folder.
- Improve gathering of info from the source code.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [x] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
