### PR TITLE
🩹 [Patch]: Add debug and verbose logging for module import in test

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -290,10 +290,10 @@ runs:
         LocalTestPath: ${{ steps.paths.outputs.LocalTestPath }}
         WorkingDirectory: ${{ inputs.WorkingDirectory }}
       with:
-        Debug: 'true'
-        Verbose: 'true'
-        Prerelease: ${{ inputs.Prerelease }}
+        Debug: ${{ inputs.Debug }}
+        Verbose: ${{ inputs.Verbose }}
         Version: ${{ inputs.Version }}
+        Prerelease: ${{ inputs.Prerelease }}
         WorkingDirectory: ${{ inputs.WorkingDirectory }}
         Path: ${{ steps.paths.outputs.TestPath }}
         StepSummary_Mode: ${{ inputs.StepSummary_Mode }}

--- a/action.yml
+++ b/action.yml
@@ -290,8 +290,8 @@ runs:
         LocalTestPath: ${{ steps.paths.outputs.LocalTestPath }}
         WorkingDirectory: ${{ inputs.WorkingDirectory }}
       with:
-        Debug: 'true'
-        Verbose: 'true'
+        Debug: ${{ inputs.Debug }}
+        Verbose: ${{ inputs.Verbose }}
         Version: ${{ inputs.Version }}
         Prerelease: ${{ inputs.Prerelease }}
         WorkingDirectory: ${{ inputs.WorkingDirectory }}

--- a/action.yml
+++ b/action.yml
@@ -290,9 +290,9 @@ runs:
         LocalTestPath: ${{ steps.paths.outputs.LocalTestPath }}
         WorkingDirectory: ${{ inputs.WorkingDirectory }}
       with:
-        Debug: ${{ inputs.Debug }}
+        Debug: 'true'
+        Verbose: 'true'
         Prerelease: ${{ inputs.Prerelease }}
-        Verbose: ${{ inputs.Verbose }}
         Version: ${{ inputs.Version }}
         WorkingDirectory: ${{ inputs.WorkingDirectory }}
         Path: ${{ steps.paths.outputs.TestPath }}

--- a/action.yml
+++ b/action.yml
@@ -290,8 +290,8 @@ runs:
         LocalTestPath: ${{ steps.paths.outputs.LocalTestPath }}
         WorkingDirectory: ${{ inputs.WorkingDirectory }}
       with:
-        Debug: ${{ inputs.Debug }}
-        Verbose: ${{ inputs.Verbose }}
+        Debug: 'true'
+        Verbose: 'true'
         Version: ${{ inputs.Version }}
         Prerelease: ${{ inputs.Prerelease }}
         WorkingDirectory: ${{ inputs.WorkingDirectory }}

--- a/scripts/tests/Module/Module.Configuration.ps1
+++ b/scripts/tests/Module/Module.Configuration.ps1
@@ -5,6 +5,9 @@
     CodeCoverage = @{
         Enabled = $true
     }
+    Debug        = @{
+        WriteDebugMessages = $true
+    }
     Output       = @{
         Verbosity = 'Detailed'
     }

--- a/scripts/tests/Module/Module.Configuration.ps1
+++ b/scripts/tests/Module/Module.Configuration.ps1
@@ -1,11 +1,11 @@
 ﻿@{
-    TestResult = @{
+    TestResult   = @{
         Enabled = $true
     }
     CodeCoverage = @{
         Enabled = $true
     }
-    Output     = @{
+    Output       = @{
         Verbosity = 'Detailed'
     }
 }

--- a/scripts/tests/Module/Module.Configuration.ps1
+++ b/scripts/tests/Module/Module.Configuration.ps1
@@ -2,6 +2,9 @@
     TestResult = @{
         Enabled = $true
     }
+    CodeCoverage = @{
+        Enabled = $true
+    }
     Output     = @{
         Verbosity = 'Detailed'
     }

--- a/scripts/tests/Module/Module.Configuration.ps1
+++ b/scripts/tests/Module/Module.Configuration.ps1
@@ -5,9 +5,6 @@
     CodeCoverage = @{
         Enabled = $true
     }
-    Debug        = @{
-        WriteDebugMessages = $true
-    }
     Output       = @{
         Verbosity = 'Detailed'
     }

--- a/scripts/tests/Module/PSModule/PSModule.Container.ps1
+++ b/scripts/tests/Module/PSModule/PSModule.Container.ps1
@@ -1,8 +1,6 @@
 ﻿@{
     Path = Get-ChildItem -Path $PSScriptRoot -Filter *.Tests.ps1 | Select-Object -ExpandProperty FullName
     Data = @{
-        Path    = $env:PSMODULE_INVOKE_PESTER_INPUT_Run_Path
-        Debug   = $false
-        Verbose = $false
+        Path = $env:PSMODULE_INVOKE_PESTER_INPUT_Run_Path
     }
 }

--- a/scripts/tests/Module/PSModule/PSModule.Container.ps1
+++ b/scripts/tests/Module/PSModule/PSModule.Container.ps1
@@ -1,8 +1,6 @@
 ﻿@{
     Path = Get-ChildItem -Path $PSScriptRoot -Filter *.Tests.ps1 | Select-Object -ExpandProperty FullName
     Data = @{
-        Path    = $env:PSMODULE_INVOKE_PESTER_INPUT_Run_Path
-        Debug   = $true
-        Verbose = $true
+        Path = $env:PSMODULE_INVOKE_PESTER_INPUT_Run_Path
     }
 }

--- a/scripts/tests/Module/PSModule/PSModule.Container.ps1
+++ b/scripts/tests/Module/PSModule/PSModule.Container.ps1
@@ -1,6 +1,8 @@
 ﻿@{
     Path = Get-ChildItem -Path $PSScriptRoot -Filter *.Tests.ps1 | Select-Object -ExpandProperty FullName
     Data = @{
-        Path = $env:PSMODULE_INVOKE_PESTER_INPUT_Run_Path
+        Path    = $env:PSMODULE_INVOKE_PESTER_INPUT_Run_Path
+        Debug   = $true
+        Verbose = $true
     }
 }

--- a/scripts/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/scripts/tests/Module/PSModule/PSModule.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'PSModule - Module tests' {
         It 'The module should be importable' {
             {
                 LogGroup 'Importing Module' {
-                    Import-Module -Name $moduleName -Force -Debug -Verbose
+                    Import-Module -Name $moduleName -Force
                 }
             } | Should -Not -Throw
         }

--- a/scripts/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/scripts/tests/Module/PSModule/PSModule.Tests.ps1
@@ -19,14 +19,8 @@ Describe 'PSModule - Module tests' {
         It 'The module should be importable' {
             {
                 LogGroup 'Importing Module' {
-                    $currentDebugPreference = $DebugPreference
-                    $currentVerbosePreference = $VerbosePreference
-                    $DebugPreference = 'Continue'
-                    $VerbosePreference = 'Continue'
                     Import-Module -Name $moduleName -Force -Verbose -Debug
-                    $DebugPreference = $currentDebugPreference
-                    $VerbosePreference = $currentVerbosePreference
-                }
+                } -Verbose -Debug
             } | Should -Not -Throw
         }
     }

--- a/scripts/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/scripts/tests/Module/PSModule/PSModule.Tests.ps1
@@ -19,13 +19,13 @@ Describe 'PSModule - Module tests' {
         It 'The module should be importable' {
             {
                 LogGroup 'Importing Module' {
-                    # $currentDebugPreference = $DebugPreference
-                    # $currentVerbosePreference = $VerbosePreference
-                    # $DebugPreference = 'Continue'
-                    # $VerbosePreference = 'Continue'
-                    Import-Module -Name $moduleName -Force -Verbose -Debug
-                    # $DebugPreference = $currentDebugPreference
-                    # $VerbosePreference = $currentVerbosePreference
+                    $currentDebugPreference = $DebugPreference
+                    $currentVerbosePreference = $VerbosePreference
+                    $DebugPreference = 'Continue'
+                    $VerbosePreference = 'Continue'
+                    Import-Module -Name $moduleName -Force
+                    $DebugPreference = $currentDebugPreference
+                    $VerbosePreference = $currentVerbosePreference
                 }
             } | Should -Not -Throw
         }

--- a/scripts/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/scripts/tests/Module/PSModule/PSModule.Tests.ps1
@@ -19,7 +19,15 @@ Describe 'PSModule - Module tests' {
         It 'The module should be importable' {
             {
                 LogGroup 'Importing Module' {
-                    Import-Module -Name $moduleName -Force
+                    #Get current debug preference and verbose preference
+                    $currentDebugPreference = $DebugPreference
+                    $currentVerbosePreference = $VerbosePreference
+                    $DebugPreference = 'Continue'
+                    $VerbosePreference = 'Continue'
+                    Import-Module -Name $moduleName -Force -Verbose -Debug
+                    #Set debug preference back to original value
+                    $DebugPreference = $currentDebugPreference
+                    $VerbosePreference = $currentVerbosePreference
                 }
             } | Should -Not -Throw
         }

--- a/scripts/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/scripts/tests/Module/PSModule/PSModule.Tests.ps1
@@ -19,13 +19,7 @@ Describe 'PSModule - Module tests' {
         It 'The module should be importable' {
             {
                 LogGroup 'Importing Module' {
-                    $currentDebugPreference = $DebugPreference
-                    $currentVerbosePreference = $VerbosePreference
-                    $DebugPreference = 'Continue'
-                    $VerbosePreference = 'Continue'
                     Import-Module -Name $moduleName -Force -Verbose -Debug
-                    $DebugPreference = $currentDebugPreference
-                    $VerbosePreference = $currentVerbosePreference
                 }
             } | Should -Not -Throw
         }

--- a/scripts/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/scripts/tests/Module/PSModule/PSModule.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'PSModule - Module tests' {
         It 'The module should be importable' {
             {
                 LogGroup 'Importing Module' {
-                    Import-Module -Name $moduleName -Force
+                    Import-Module -Name $moduleName -Force -Debug -Verbose
                 }
             } | Should -Not -Throw
         }

--- a/scripts/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/scripts/tests/Module/PSModule/PSModule.Tests.ps1
@@ -19,8 +19,15 @@ Describe 'PSModule - Module tests' {
         It 'The module should be importable' {
             {
                 LogGroup 'Importing Module' {
-                    Import-Module -Name $moduleName -Force -Verbose -Debug
-                } -Verbose -Debug
+                    $currentDebugPreference = $DebugPreference
+                    $currentVerbosePreference = $VerbosePreference
+                    $DebugPreference = 'Continue'
+                    $VerbosePreference = 'Continue'
+                    Get-Module -Name $moduleName | Remove-Module -Force
+                    Import-Module -Name $moduleName -Verbose -Debug
+                    $DebugPreference = $currentDebugPreference
+                    $VerbosePreference = $currentVerbosePreference
+                }
             } | Should -Not -Throw
         }
     }

--- a/scripts/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/scripts/tests/Module/PSModule/PSModule.Tests.ps1
@@ -19,13 +19,11 @@ Describe 'PSModule - Module tests' {
         It 'The module should be importable' {
             {
                 LogGroup 'Importing Module' {
-                    #Get current debug preference and verbose preference
                     $currentDebugPreference = $DebugPreference
                     $currentVerbosePreference = $VerbosePreference
                     $DebugPreference = 'Continue'
                     $VerbosePreference = 'Continue'
                     Import-Module -Name $moduleName -Force -Verbose -Debug
-                    #Set debug preference back to original value
                     $DebugPreference = $currentDebugPreference
                     $VerbosePreference = $currentVerbosePreference
                 }

--- a/scripts/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/scripts/tests/Module/PSModule/PSModule.Tests.ps1
@@ -19,7 +19,13 @@ Describe 'PSModule - Module tests' {
         It 'The module should be importable' {
             {
                 LogGroup 'Importing Module' {
+                    $currentDebugPreference = $DebugPreference
+                    $currentVerbosePreference = $VerbosePreference
+                    $DebugPreference = 'Continue'
+                    $VerbosePreference = 'Continue'
                     Import-Module -Name $moduleName -Force -Verbose -Debug
+                    $DebugPreference = $currentDebugPreference
+                    $VerbosePreference = $currentVerbosePreference
                 }
             } | Should -Not -Throw
         }

--- a/scripts/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/scripts/tests/Module/PSModule/PSModule.Tests.ps1
@@ -17,20 +17,28 @@ BeforeAll {
 Describe 'PSModule - Module tests' {
     Context 'Module' {
         It 'The module should be importable' {
-            { Import-Module -Name $moduleName } | Should -Not -Throw
+            {
+                LogGroup 'Importing Module' {
+                    Import-Module -Name $moduleName -Debug -Verbose -Force
+                }
+            } | Should -Not -Throw
         }
     }
 
     Context 'Module Manifest' {
         It 'Module Manifest exists' {
-            $result = Test-Path -Path $moduleManifestPath
-            $result | Should -Be $true
-            Write-Verbose $result
+            LogGroup 'Module manifest' {
+                $result = Test-Path -Path $moduleManifestPath
+                $result | Should -Be $true
+                Write-Verbose $result
+            }
         }
         It 'Module Manifest is valid' {
-            $result = Test-ModuleManifest -Path $moduleManifestPath
-            $result | Should -Not -Be $null
-            Write-Verbose $result
+            LogGroup 'Validating Module Manifest' {
+                $result = Test-ModuleManifest -Path $moduleManifestPath
+                $result | Should -Not -Be $null
+                Write-Verbose $result
+            }
         }
         # It 'has a valid license URL' {}
         # It 'has a valid project URL' {}

--- a/scripts/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/scripts/tests/Module/PSModule/PSModule.Tests.ps1
@@ -19,13 +19,13 @@ Describe 'PSModule - Module tests' {
         It 'The module should be importable' {
             {
                 LogGroup 'Importing Module' {
-                    $currentDebugPreference = $DebugPreference
-                    $currentVerbosePreference = $VerbosePreference
-                    $DebugPreference = 'Continue'
-                    $VerbosePreference = 'Continue'
+                    # $currentDebugPreference = $DebugPreference
+                    # $currentVerbosePreference = $VerbosePreference
+                    # $DebugPreference = 'Continue'
+                    # $VerbosePreference = 'Continue'
                     Import-Module -Name $moduleName -Force -Verbose -Debug
-                    $DebugPreference = $currentDebugPreference
-                    $VerbosePreference = $currentVerbosePreference
+                    # $DebugPreference = $currentDebugPreference
+                    # $VerbosePreference = $currentVerbosePreference
                 }
             } | Should -Not -Throw
         }

--- a/scripts/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/scripts/tests/Module/PSModule/PSModule.Tests.ps1
@@ -2,6 +2,10 @@
     'PSReviewUnusedParameter', 'Path',
     Justification = 'Path is used to specify the path to the module to test.'
 )]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidUsingWriteHost', '',
+    Justification = 'Log outputs to GitHub Actions logs.'
+)]
 [CmdLetBinding()]
 Param(
     [Parameter(Mandatory)]
@@ -17,17 +21,7 @@ BeforeAll {
 Describe 'PSModule - Module tests' {
     Context 'Module' {
         It 'The module should be importable' {
-            {
-                LogGroup 'Importing Module' {
-                    $currentDebugPreference = $DebugPreference
-                    $currentVerbosePreference = $VerbosePreference
-                    $DebugPreference = 'Continue'
-                    $VerbosePreference = 'Continue'
-                    Import-Module -Name $moduleName
-                    $DebugPreference = $currentDebugPreference
-                    $VerbosePreference = $currentVerbosePreference
-                }
-            } | Should -Not -Throw
+            { Import-Module -Name $moduleName } | Should -Not -Throw
         }
     }
 
@@ -36,14 +30,14 @@ Describe 'PSModule - Module tests' {
             LogGroup 'Module manifest' {
                 $result = Test-Path -Path $moduleManifestPath
                 $result | Should -Be $true
-                Write-Verbose $result
+                Write-Host "$($result | Format-List | Out-String)"
             }
         }
         It 'Module Manifest is valid' {
             LogGroup 'Validating Module Manifest' {
                 $result = Test-ModuleManifest -Path $moduleManifestPath
                 $result | Should -Not -Be $null
-                Write-Verbose $result
+                Write-Host "$($result | Format-List | Out-String)"
             }
         }
         # It 'has a valid license URL' {}

--- a/scripts/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/scripts/tests/Module/PSModule/PSModule.Tests.ps1
@@ -19,14 +19,10 @@ Describe 'PSModule - Module tests' {
         It 'The module should be importable' {
             {
                 LogGroup 'Importing Module' {
-                    $currentDebugPreference = $DebugPreference
-                    $currentVerbosePreference = $VerbosePreference
-                    $DebugPreference = 'Continue'
-                    $VerbosePreference = 'Continue'
-                    Get-Module -Name $moduleName | Remove-Module -Force
-                    Import-Module -Name $moduleName -Verbose -Debug
-                    $DebugPreference = $currentDebugPreference
-                    $VerbosePreference = $currentVerbosePreference
+                    Import-Module -Name $moduleName -ArgumentList @{
+                        Debug   = $true
+                        Verbose = $true
+                    }
                 }
             } | Should -Not -Throw
         }

--- a/scripts/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/scripts/tests/Module/PSModule/PSModule.Tests.ps1
@@ -19,10 +19,13 @@ Describe 'PSModule - Module tests' {
         It 'The module should be importable' {
             {
                 LogGroup 'Importing Module' {
-                    Import-Module -Name $moduleName -ArgumentList @{
-                        Debug   = $true
-                        Verbose = $true
-                    }
+                    $currentDebugPreference = $DebugPreference
+                    $currentVerbosePreference = $VerbosePreference
+                    $DebugPreference = 'Continue'
+                    $VerbosePreference = 'Continue'
+                    Import-Module -Name $moduleName
+                    $DebugPreference = $currentDebugPreference
+                    $VerbosePreference = $currentVerbosePreference
                 }
             } | Should -Not -Throw
         }

--- a/scripts/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/scripts/tests/Module/PSModule/PSModule.Tests.ps1
@@ -23,7 +23,7 @@ Describe 'PSModule - Module tests' {
                     $currentVerbosePreference = $VerbosePreference
                     $DebugPreference = 'Continue'
                     $VerbosePreference = 'Continue'
-                    Import-Module -Name $moduleName -Force
+                    Import-Module -Name $moduleName -Force -Verbose -Debug
                     $DebugPreference = $currentDebugPreference
                     $VerbosePreference = $currentVerbosePreference
                 }

--- a/scripts/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/scripts/tests/Module/PSModule/PSModule.Tests.ps1
@@ -19,7 +19,7 @@ Describe 'PSModule - Module tests' {
         It 'The module should be importable' {
             {
                 LogGroup 'Importing Module' {
-                    Import-Module -Name $moduleName -Debug -Verbose -Force
+                    Import-Module -Name $moduleName -Force
                 }
             } | Should -Not -Throw
         }

--- a/scripts/tests/SourceCode/PSModule/PSModule.Container.ps1
+++ b/scripts/tests/SourceCode/PSModule/PSModule.Container.ps1
@@ -3,7 +3,5 @@
     Data = @{
         Path      = $env:PSMODULE_INVOKE_PESTER_INPUT_Run_Path
         TestsPath = $env:LocalTestPath
-        Debug     = $false
-        Verbose   = $false
     }
 }

--- a/tests/outputTestRepo/outputs/module/PSModuleTest/PSModuleTest.psm1
+++ b/tests/outputTestRepo/outputs/module/PSModuleTest/PSModuleTest.psm1
@@ -3,42 +3,42 @@
 param()
 
 $scriptName = $MyInvocation.MyCommand.Name
-Write-Verbose "[$scriptName] Importing module"
+Write-Debug "[$scriptName] Importing module"
 
 #region - Data import
-Write-Verbose "[$scriptName] - [data] - Processing folder"
+Write-Debug "[$scriptName] - [data] - Processing folder"
 $dataFolder = (Join-Path $PSScriptRoot 'data')
-Write-Verbose "[$scriptName] - [data] - [$dataFolder]"
+Write-Debug "[$scriptName] - [data] - [$dataFolder]"
 Get-ChildItem -Path "$dataFolder" -Recurse -Force -Include '*.psd1' -ErrorAction SilentlyContinue | ForEach-Object {
-    Write-Verbose "[$scriptName] - [data] - [$($_.Name)] - Importing"
+    Write-Debug "[$scriptName] - [data] - [$($_.Name)] - Importing"
     New-Variable -Name $_.BaseName -Value (Import-PowerShellDataFile -Path $_.FullName) -Force
-    Write-Verbose "[$scriptName] - [data] - [$($_.Name)] - Done"
+    Write-Debug "[$scriptName] - [data] - [$($_.Name)] - Done"
 }
 
-Write-Verbose "[$scriptName] - [data] - Done"
+Write-Debug "[$scriptName] - [data] - Done"
 #endregion - Data import
 
 #region - From /init
-Write-Verbose "[$scriptName] - [/init] - Processing folder"
+Write-Debug "[$scriptName] - [/init] - Processing folder"
 
 #region - From /init/initializer.ps1
-Write-Verbose "[$scriptName] - [/init/initializer.ps1] - Importing"
+Write-Debug "[$scriptName] - [/init/initializer.ps1] - Importing"
 
 Write-Verbose '-------------------------------'
 Write-Verbose '---  THIS IS AN INITIALIZER ---'
 Write-Verbose '-------------------------------'
 
-Write-Verbose "[$scriptName] - [/init/initializer.ps1] - Done"
+Write-Debug "[$scriptName] - [/init/initializer.ps1] - Done"
 #endregion - From /init/initializer.ps1
 
-Write-Verbose "[$scriptName] - [/init] - Done"
+Write-Debug "[$scriptName] - [/init] - Done"
 #endregion - From /init
 
 #region - From /classes
-Write-Verbose "[$scriptName] - [/classes] - Processing folder"
+Write-Debug "[$scriptName] - [/classes] - Processing folder"
 
 #region - From /classes/Book.ps1
-Write-Verbose "[$scriptName] - [/classes/Book.ps1] - Importing"
+Write-Debug "[$scriptName] - [/classes/Book.ps1] - Importing"
 
 class Book {
     # Class properties
@@ -86,10 +86,10 @@ class Book {
     }
 }
 
-Write-Verbose "[$scriptName] - [/classes/Book.ps1] - Done"
+Write-Debug "[$scriptName] - [/classes/Book.ps1] - Done"
 #endregion - From /classes/Book.ps1
 #region - From /classes/BookList.ps1
-Write-Verbose "[$scriptName] - [/classes/BookList.ps1] - Importing"
+Write-Debug "[$scriptName] - [/classes/BookList.ps1] - Importing"
 
 class BookList {
     # Static property to hold the list of books
@@ -178,17 +178,17 @@ class BookList {
     }
 }
 
-Write-Verbose "[$scriptName] - [/classes/BookList.ps1] - Done"
+Write-Debug "[$scriptName] - [/classes/BookList.ps1] - Done"
 #endregion - From /classes/BookList.ps1
 
-Write-Verbose "[$scriptName] - [/classes] - Done"
+Write-Debug "[$scriptName] - [/classes] - Done"
 #endregion - From /classes
 
 #region - From /private
-Write-Verbose "[$scriptName] - [/private] - Processing folder"
+Write-Debug "[$scriptName] - [/private] - Processing folder"
 
 #region - From /private/Get-InternalPSModule.ps1
-Write-Verbose "[$scriptName] - [/private/Get-InternalPSModule.ps1] - Importing"
+Write-Debug "[$scriptName] - [/private/Get-InternalPSModule.ps1] - Importing"
 
 Function Get-InternalPSModule {
     <#
@@ -209,10 +209,10 @@ Function Get-InternalPSModule {
     Write-Output "Hello, $Name!"
 }
 
-Write-Verbose "[$scriptName] - [/private/Get-InternalPSModule.ps1] - Done"
+Write-Debug "[$scriptName] - [/private/Get-InternalPSModule.ps1] - Done"
 #endregion - From /private/Get-InternalPSModule.ps1
 #region - From /private/Set-InternalPSModule.ps1
-Write-Verbose "[$scriptName] - [/private/Set-InternalPSModule.ps1] - Importing"
+Write-Debug "[$scriptName] - [/private/Set-InternalPSModule.ps1] - Importing"
 
 Function Set-InternalPSModule {
     <#
@@ -237,17 +237,17 @@ Function Set-InternalPSModule {
     Write-Output "Hello, $Name!"
 }
 
-Write-Verbose "[$scriptName] - [/private/Set-InternalPSModule.ps1] - Done"
+Write-Debug "[$scriptName] - [/private/Set-InternalPSModule.ps1] - Done"
 #endregion - From /private/Set-InternalPSModule.ps1
 
-Write-Verbose "[$scriptName] - [/private] - Done"
+Write-Debug "[$scriptName] - [/private] - Done"
 #endregion - From /private
 
 #region - From /public
-Write-Verbose "[$scriptName] - [/public] - Processing folder"
+Write-Debug "[$scriptName] - [/public] - Processing folder"
 
 #region - From /public/Get-PSModuleTest.ps1
-Write-Verbose "[$scriptName] - [/public/Get-PSModuleTest.ps1] - Importing"
+Write-Debug "[$scriptName] - [/public/Get-PSModuleTest.ps1] - Importing"
 
 #Requires -Modules Utilities
 
@@ -272,10 +272,10 @@ function Get-PSModuleTest {
     Write-Output "Hello, $Name!"
 }
 
-Write-Verbose "[$scriptName] - [/public/Get-PSModuleTest.ps1] - Done"
+Write-Debug "[$scriptName] - [/public/Get-PSModuleTest.ps1] - Done"
 #endregion - From /public/Get-PSModuleTest.ps1
 #region - From /public/New-PSModuleTest.ps1
-Write-Verbose "[$scriptName] - [/public/New-PSModuleTest.ps1] - Importing"
+Write-Debug "[$scriptName] - [/public/New-PSModuleTest.ps1] - Importing"
 
 #Requires -Modules @{ModuleName='PSSemVer'; ModuleVersion='1.0'}
 
@@ -304,10 +304,10 @@ function New-PSModuleTest {
     Write-Output "Hello, $Name!"
 }
 
-Write-Verbose "[$scriptName] - [/public/New-PSModuleTest.ps1] - Done"
+Write-Debug "[$scriptName] - [/public/New-PSModuleTest.ps1] - Done"
 #endregion - From /public/New-PSModuleTest.ps1
 #region - From /public/Set-PSModuleTest.ps1
-Write-Verbose "[$scriptName] - [/public/Set-PSModuleTest.ps1] - Importing"
+Write-Debug "[$scriptName] - [/public/Set-PSModuleTest.ps1] - Importing"
 
 function Set-PSModuleTest {
     <#
@@ -336,10 +336,10 @@ function Set-PSModuleTest {
     }
 }
 
-Write-Verbose "[$scriptName] - [/public/Set-PSModuleTest.ps1] - Done"
+Write-Debug "[$scriptName] - [/public/Set-PSModuleTest.ps1] - Done"
 #endregion - From /public/Set-PSModuleTest.ps1
 #region - From /public/Test-PSModuleTest.ps1
-Write-Verbose "[$scriptName] - [/public/Test-PSModuleTest.ps1] - Importing"
+Write-Debug "[$scriptName] - [/public/Test-PSModuleTest.ps1] - Importing"
 
 function Test-PSModuleTest {
     <#
@@ -362,19 +362,19 @@ function Test-PSModuleTest {
     Write-Output "Hello, $Name!"
 }
 
-Write-Verbose "[$scriptName] - [/public/Test-PSModuleTest.ps1] - Done"
+Write-Debug "[$scriptName] - [/public/Test-PSModuleTest.ps1] - Done"
 #endregion - From /public/Test-PSModuleTest.ps1
 
-Write-Verbose "[$scriptName] - [/public] - Done"
+Write-Debug "[$scriptName] - [/public] - Done"
 #endregion - From /public
 
 #region - From /finally.ps1
-Write-Verbose "[$scriptName] - [/finally.ps1] - Importing"
+Write-Debug "[$scriptName] - [/finally.ps1] - Importing"
 
 Write-Verbose '------------------------------'
 Write-Verbose '---  THIS IS A LAST LOADER ---'
 Write-Verbose '------------------------------'
-Write-Verbose "[$scriptName] - [/finally.ps1] - Done"
+Write-Debug "[$scriptName] - [/finally.ps1] - Done"
 #endregion - From /finally.ps1
 
 $exports = @{

--- a/tests/outputTestRepo/outputs/module/PSModuleTest/scripts/loader.ps1
+++ b/tests/outputTestRepo/outputs/module/PSModuleTest/scripts/loader.ps1
@@ -1,3 +1,3 @@
-﻿Write-Verbose '-------------------------'
-Write-Verbose '---  THIS IS A LOADER ---'
-Write-Verbose '-------------------------'
+﻿Write-Debug '-------------------------'
+Write-Debug '---  THIS IS A LOADER ---'
+Write-Debug '-------------------------'

--- a/tests/outputTestRepo/outputs/module/PSModuleTest/scripts/loader.ps1
+++ b/tests/outputTestRepo/outputs/module/PSModuleTest/scripts/loader.ps1
@@ -1,3 +1,3 @@
-﻿Write-Debug '-------------------------'
-Write-Debug '---  THIS IS A LOADER ---'
-Write-Debug '-------------------------'
+﻿Write-Verbose '-------------------------'
+Write-Verbose '---  THIS IS A LOADER ---'
+Write-Verbose '-------------------------'


### PR DESCRIPTION
## Description

This pull request introduces several changes to improve logging, enhance test configuration, and streamline code readability in the PowerShell module and its associated tests. Key updates include adding code coverage settings.

### Logging Improvements

* Replaced all occurrences of `Write-Verbose` with `Write-Debug` in `tests/outputTestRepo/outputs/module/PSModuleTest/PSModuleTest.psm1`.

### Test Configuration Enhancements

* ⚠️ Added a `CodeCoverage` section with `Enabled = $true` in `scripts/tests/Module/Module.Configuration.ps1` to enable code coverage reporting during tests.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [ ] 🪲 [Fix]
- [x] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
