### PR TITLE
🪲 [Fix]: Remove unnecessary LogGroup wrappers in tests

### DIFF
--- a/scripts/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/scripts/tests/Module/PSModule/PSModule.Tests.ps1
@@ -27,18 +27,14 @@ Describe 'PSModule - Module tests' {
 
     Context 'Module Manifest' {
         It 'Module Manifest exists' {
-            LogGroup 'Module manifest' {
-                $result = Test-Path -Path $moduleManifestPath
-                $result | Should -Be $true
-                Write-Host "$($result | Format-List | Out-String)"
-            }
+            $result = Test-Path -Path $moduleManifestPath
+            $result | Should -Be $true
+            Write-Host "$($result | Format-List | Out-String)"
         }
         It 'Module Manifest is valid' {
-            LogGroup 'Validating Module Manifest' {
-                $result = Test-ModuleManifest -Path $moduleManifestPath
-                $result | Should -Not -Be $null
-                Write-Host "$($result | Format-List | Out-String)"
-            }
+            $result = Test-ModuleManifest -Path $moduleManifestPath
+            $result | Should -Not -Be $null
+            Write-Host "$($result | Format-List | Out-String)"
         }
         # It 'has a valid license URL' {}
         # It 'has a valid project URL' {}


### PR DESCRIPTION
## Description

This pull request simplifies the `PSModule.Tests.ps1` script by removing unnecessary logging groups within the test cases which would autoload GitHub and its dependencies, breaking on tests for its dependencies (Sodium, Uri, CaseStyle, etc.).

Simplification of test cases:

* Removed `LogGroup` blocks from the `Module Manifest exists` and `Module Manifest is valid` tests.

## Type of change

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [ ] 📖 [Docs]
- [x] 🪲 [Fix]
- [ ] 🩹 [Patch]
- [ ] ⚠️ [Security fix]
- [ ] 🚀 [Feature]
- [ ] 🌟 [Breaking change]

## Checklist

<!-- Use the check-boxes [x] on the options that are relevant. -->

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
