### PR TITLE
🩹 [Patch]: Encode all PowerShell files using UTF8 with BOM

### DIFF
--- a/tests/srcTestRepo/src/variables/public/Planets.ps1
+++ b/tests/srcTestRepo/src/variables/public/Planets.ps1
@@ -1,4 +1,4 @@
-$script:Planets = @(
+﻿$script:Planets = @(
     @{
         Name      = 'Mercury'
         Mass      = 0.330

--- a/tests/srcWithManifestTestRepo/src/variables/public/Planets.ps1
+++ b/tests/srcWithManifestTestRepo/src/variables/public/Planets.ps1
@@ -1,4 +1,4 @@
-$script:Planets = @(
+﻿$script:Planets = @(
     @{
         Name      = 'Mercury'
         Mass      = 0.330


### PR DESCRIPTION
## Description

This pull request introduces a minor change to the `Planets.ps1` files in two test repositories. The only modification is the addition of a Unicode Byte Order Mark (BOM) at the beginning of each file, which does not affect script functionality but may impact how some editors interpret file encoding. 

- Added a BOM to the start of `tests/srcTestRepo/src/variables/public/Planets.ps1`
- Added a BOM to the start of `tests/srcWithManifestTestRepo/src/variables/public/Planets.ps1`