### PR TITLE
⚙️ [Maintenance]: Update super-linter to v8.4.0

### DIFF
--- a/.github/linters/.codespellrc
+++ b/.github/linters/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+skip = ./.github/linters

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -28,7 +28,6 @@ jobs:
         uses: super-linter/super-linter@12562e48d7059cf666c43a4ecb0d3b5a2b31bd9e # v8.4.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          SUPPRESS_OUTPUT_ON_SUCCESS: true
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_JSCPD: false
           VALIDATE_JSON_PRETTIER: false

--- a/.github/workflows/Linter.yml
+++ b/.github/workflows/Linter.yml
@@ -25,9 +25,10 @@ jobs:
           persist-credentials: false
 
       - name: Lint code base
-        uses: super-linter/super-linter@d5b0a2ab116623730dd094f15ddc1b6b25bf7b99 # v8.3.2
+        uses: super-linter/super-linter@12562e48d7059cf666c43a4ecb0d3b5a2b31bd9e # v8.4.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
+          SUPPRESS_OUTPUT_ON_SUCCESS: true
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_JSCPD: false
           VALIDATE_JSON_PRETTIER: false

--- a/src/tests/SourceCode/PSModule/PSModule.Tests.ps1
+++ b/src/tests/SourceCode/PSModule/PSModule.Tests.ps1
@@ -163,7 +163,7 @@ Describe 'PSModule - SourceCode tests' {
             $issues -join [Environment]::NewLine |
                 Should -BeNullOrEmpty -Because "the script should use '`$null = ...' instead of '... | Out-Null'"
         }
-        It 'Should not use ternary operations for compatability reasons (ID: NoTernary)' -Skip {
+        It 'Should not use ternary operations for compatibility reasons (ID: NoTernary)' -Skip {
             $issues = @('')
             $scriptFiles | ForEach-Object {
                 $filePath = $_.FullName
@@ -179,7 +179,7 @@ Describe 'PSModule - SourceCode tests' {
                 }
             }
             $issues -join [Environment]::NewLine |
-                Should -BeNullOrEmpty -Because 'the script should not use ternary operations for compatability with PS 5.1 and below'
+                Should -BeNullOrEmpty -Because 'the script should not use ternary operations for compatibility with PS 5.1 and below'
         }
         It 'all powershell keywords are lowercase (ID: LowercaseKeywords)' {
             $issues = @('')


### PR DESCRIPTION
## Description

Updates super-linter from v8.3.2 to v8.4.0.

## Changes

- Updated `super-linter/super-linter` to v8.4.0 (`12562e48d7059cf666c43a4ecb0d3b5a2b31bd9e`)
- Added `.codespellrc` configuration file for codespell linter

## References

- [super-linter v8.4.0 release](https://github.com/super-linter/super-linter/releases/tag/v8.4.0)