### PR TITLE
🩹 [Patch]: Framework-generated boilerplate code now tested and covered

### DIFF
--- a/src/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/src/tests/Module/PSModule/PSModule.Tests.ps1
@@ -15,13 +15,38 @@ param(
 BeforeAll {
     $moduleName = Split-Path -Path (Split-Path -Path $Path -Parent) -Leaf
     $moduleManifestPath = Join-Path -Path $Path -ChildPath "$moduleName.psd1"
+    $moduleRootPath = Join-Path -Path $Path -ChildPath "$moduleName.psm1"
     Write-Verbose "Module Manifest Path: [$moduleManifestPath]"
+    Write-Verbose "Module Root Path: [$moduleRootPath]"
+
+    # Discover public classes and enums from the compiled module source.
+    # The class exporter region is injected by Build-PSModule when classes/public contains types.
+    $moduleContent = if (Test-Path -Path $moduleRootPath) { Get-Content -Path $moduleRootPath -Raw } else { '' }
+    $hasClassExporter = $moduleContent -match '#region\s+Class exporter'
+
+    # Extract expected class and enum names from the class exporter block.
+    $expectedClassNames = @()
+    $expectedEnumNames = @()
+    if ($hasClassExporter) {
+        # Match $ExportableClasses = @( ... ) block
+        if ($moduleContent -match '\$ExportableClasses\s*=\s*@\(([\s\S]*?)\)') {
+            $expectedClassNames = [regex]::Matches($Matches[1], '\[([^\]]+)\]') | ForEach-Object { $_.Groups[1].Value }
+        }
+        # Match $ExportableEnums = @( ... ) block
+        if ($moduleContent -match '\$ExportableEnums\s*=\s*@\(([\s\S]*?)\)') {
+            $expectedEnumNames = [regex]::Matches($Matches[1], '\[([^\]]+)\]') | ForEach-Object { $_.Groups[1].Value }
+        }
+    }
+    $expectedTypeNames = @($expectedEnumNames) + @($expectedClassNames) | Where-Object { $_ }
+    Write-Host "Has class exporter: $hasClassExporter"
+    Write-Host "Expected classes: $($expectedClassNames -join ', ')"
+    Write-Host "Expected enums: $($expectedEnumNames -join ', ')"
 }
 
 Describe 'PSModule - Module tests' {
     Context 'Module' {
         It 'The module should be importable' {
-            { Import-Module -Name $moduleName } | Should -Not -Throw
+            { Import-Module -Name $moduleName -Force } | Should -Not -Throw
         }
     }
 
@@ -36,9 +61,49 @@ Describe 'PSModule - Module tests' {
             $result | Should -Not -Be $null
             Write-Host "$($result | Format-List | Out-String)"
         }
-        # It 'has a valid license URL' {}
-        # It 'has a valid project URL' {}
-        # It 'has a valid icon URL' {}
-        # It 'has a valid help URL' {}
+    }
+
+    Context 'Framework - IsWindows compatibility shim' {
+        It 'Should have $IsWindows defined' {
+            # The framework injects "$IsWindows = $true" for PowerShell 5.1 (Desktop edition).
+            # On PS 7+ (Core), $IsWindows is a built-in automatic variable.
+            # Either way, it must be defined after module import.
+            $variable = Get-Variable -Name 'IsWindows' -ErrorAction SilentlyContinue
+            $variable | Should -Not -BeNullOrEmpty -Because 'the framework injects a compatibility shim for PS 5.1'
+        }
+    }
+
+    Context 'Framework - Type accelerator registration' -Skip:(-not $hasClassExporter) {
+        BeforeAll {
+            $typeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')::Get
+        }
+
+        It 'Should register public enum [<_>] as a type accelerator' -ForEach $expectedEnumNames {
+            $typeAccelerators.Keys | Should -Contain $_ -Because 'the framework registers public enums as type accelerators'
+        }
+
+        It 'Should register public class [<_>] as a type accelerator' -ForEach $expectedClassNames {
+            $typeAccelerators.Keys | Should -Contain $_ -Because 'the framework registers public classes as type accelerators'
+        }
+    }
+
+    Context 'Framework - Module OnRemove cleanup' -Skip:(-not $hasClassExporter) {
+        It 'Should clean up type accelerators when the module is removed' {
+            # Capture type names before removal
+            $typeNames = $expectedTypeNames.Clone()
+            $typeNames | Should -Not -BeNullOrEmpty -Because 'there should be types to verify cleanup for'
+
+            # Remove the module to trigger the OnRemove hook
+            Remove-Module -Name $moduleName -Force
+
+            # Verify type accelerators are cleaned up
+            $typeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')::Get
+            foreach ($typeName in $typeNames) {
+                $typeAccelerators.Keys | Should -Not -Contain $typeName -Because "the OnRemove hook should remove type accelerator [$typeName]"
+            }
+
+            # Re-import the module for any subsequent tests
+            Import-Module -Name $moduleName -Force
+        }
     }
 }

--- a/src/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/src/tests/Module/PSModule/PSModule.Tests.ps1
@@ -64,7 +64,8 @@ Describe 'PSModule - Module tests' {
 
     Context 'Framework - IsWindows compatibility shim' {
         BeforeAll {
-            $script:moduleRef = Import-Module -Name $moduleManifestPath -Force -PassThru
+            Import-Module -Name $moduleManifestPath -Force
+            $script:moduleRef = Get-Module -Name $moduleName
         }
         It 'Should have $IsWindows defined in the module scope' {
             # The framework injects "$IsWindows = $true" for PowerShell 5.1 (Desktop edition).

--- a/src/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/src/tests/Module/PSModule/PSModule.Tests.ps1
@@ -84,23 +84,22 @@ Describe 'PSModule - Module tests' {
         }
     }
 
-    Context 'Framework - Module OnRemove cleanup' -Skip:(-not $hasClassExporter) {
-        It 'Should clean up type accelerators when the module is removed' {
-            # Capture type names before removal
-            $typeNames = @(@($expectedEnumNames) + @($expectedClassNames) | Where-Object { $_ })
-            $typeNames | Should -Not -BeNullOrEmpty -Because 'there should be types to verify cleanup for'
-
+    Context 'Framework - Module OnRemove cleanup' {
+        It 'Should remove the module cleanly and re-import without errors' {
             # Remove the module to trigger the OnRemove hook
-            Remove-Module -Name $moduleName -Force
+            { Remove-Module -Name $moduleName -Force } | Should -Not -Throw
 
-            # Verify type accelerators are cleaned up
-            $typeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')::Get
-            foreach ($typeName in $typeNames) {
-                $typeAccelerators.Keys | Should -Not -Contain $typeName -Because "the OnRemove hook should remove type accelerator [$typeName]"
+            # Verify type accelerators are cleaned up when class exporter is present
+            if ($hasClassExporter) {
+                $typeNames = @(@($expectedEnumNames) + @($expectedClassNames) | Where-Object { $_ })
+                $typeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')::Get
+                foreach ($typeName in $typeNames) {
+                    $typeAccelerators.Keys | Should -Not -Contain $typeName -Because "the OnRemove hook should remove type accelerator [$typeName]"
+                }
             }
 
             # Re-import the module for any subsequent tests
-            Import-Module -Name $moduleName -Force
+            { Import-Module -Name $moduleName -Force } | Should -Not -Throw
         }
     }
 }

--- a/src/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/src/tests/Module/PSModule/PSModule.Tests.ps1
@@ -45,7 +45,7 @@ BeforeAll {
 Describe 'PSModule - Module tests' {
     Context 'Module' {
         It 'The module should be importable' {
-            { Import-Module -Name $moduleName -Force } | Should -Not -Throw
+            { Import-Module -Name $moduleManifestPath -Force } | Should -Not -Throw
         }
     }
 
@@ -63,16 +63,22 @@ Describe 'PSModule - Module tests' {
     }
 
     Context 'Framework - IsWindows compatibility shim' {
+        BeforeAll {
+            $script:moduleRef = Import-Module -Name $moduleManifestPath -Force -PassThru
+        }
         It 'Should have $IsWindows defined in the module scope' {
             # The framework injects "$IsWindows = $true" for PowerShell 5.1 (Desktop edition).
             # On PS 7+ (Core), $IsWindows is a built-in automatic variable.
             # The variable is set inside the module scope and is not exported, so we must check from within the module.
-            $isWindowsDefined = & (Get-Module $moduleName) { Get-Variable -Name 'IsWindows' -ErrorAction SilentlyContinue }
+            $isWindowsDefined = & $script:moduleRef { Get-Variable -Name 'IsWindows' -ErrorAction SilentlyContinue }
             $isWindowsDefined | Should -Not -BeNullOrEmpty -Because 'the framework injects a compatibility shim for PS 5.1'
         }
     }
 
     Context 'Framework - Type accelerator registration' -Skip:(-not $hasClassExporter) {
+        BeforeAll {
+            Import-Module -Name $moduleManifestPath -Force
+        }
         It 'Should register public enum [<_>] as a type accelerator' -ForEach $expectedEnumNames {
             $registered = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')::Get
             $registered.Keys | Should -Contain $_ -Because 'the framework registers public enums as type accelerators'
@@ -85,22 +91,27 @@ Describe 'PSModule - Module tests' {
     }
 
     Context 'Framework - Module OnRemove cleanup' -Skip:(-not $hasClassExporter) {
+        BeforeAll {
+            Import-Module -Name $moduleManifestPath -Force
+        }
         It 'Should clean up type accelerators when the module is removed' {
             # Capture type names before removal
             $typeNames = @(@($expectedEnumNames) + @($expectedClassNames) | Where-Object { $_ })
             $typeNames | Should -Not -BeNullOrEmpty -Because 'there should be types to verify cleanup for'
 
-            # Remove the module to trigger the OnRemove hook
-            Remove-Module -Name $moduleName -Force
+            try {
+                # Remove the module to trigger the OnRemove hook
+                Remove-Module -Name $moduleName -Force
 
-            # Verify type accelerators are cleaned up
-            $typeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')::Get
-            foreach ($typeName in $typeNames) {
-                $typeAccelerators.Keys | Should -Not -Contain $typeName -Because "the OnRemove hook should remove type accelerator [$typeName]"
+                # Verify type accelerators are cleaned up
+                $typeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')::Get
+                foreach ($typeName in $typeNames) {
+                    $typeAccelerators.Keys | Should -Not -Contain $typeName -Because "the OnRemove hook should remove type accelerator [$typeName]"
+                }
+            } finally {
+                # Re-import the module for any subsequent tests
+                Import-Module -Name $moduleManifestPath -Force
             }
-
-            # Re-import the module for any subsequent tests
-            Import-Module -Name $moduleName -Force
         }
     }
 }

--- a/src/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/src/tests/Module/PSModule/PSModule.Tests.ps1
@@ -37,7 +37,6 @@ BeforeAll {
             $expectedEnumNames = [regex]::Matches($Matches[1], '\[([^\]]+)\]') | ForEach-Object { $_.Groups[1].Value }
         }
     }
-    $expectedTypeNames = @($expectedEnumNames) + @($expectedClassNames) | Where-Object { $_ }
     Write-Host "Has class exporter: $hasClassExporter"
     Write-Host "Expected classes: $($expectedClassNames -join ', ')"
     Write-Host "Expected enums: $($expectedEnumNames -join ', ')"
@@ -64,33 +63,31 @@ Describe 'PSModule - Module tests' {
     }
 
     Context 'Framework - IsWindows compatibility shim' {
-        It 'Should have $IsWindows defined' {
+        It 'Should have $IsWindows defined in the module scope' {
             # The framework injects "$IsWindows = $true" for PowerShell 5.1 (Desktop edition).
             # On PS 7+ (Core), $IsWindows is a built-in automatic variable.
-            # Either way, it must be defined after module import.
-            $variable = Get-Variable -Name 'IsWindows' -ErrorAction SilentlyContinue
-            $variable | Should -Not -BeNullOrEmpty -Because 'the framework injects a compatibility shim for PS 5.1'
+            # The variable is set inside the module scope and is not exported, so we must check from within the module.
+            $isWindowsDefined = & (Get-Module $moduleName) { Get-Variable -Name 'IsWindows' -ErrorAction SilentlyContinue }
+            $isWindowsDefined | Should -Not -BeNullOrEmpty -Because 'the framework injects a compatibility shim for PS 5.1'
         }
     }
 
     Context 'Framework - Type accelerator registration' -Skip:(-not $hasClassExporter) {
-        BeforeAll {
-            $typeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')::Get
-        }
-
         It 'Should register public enum [<_>] as a type accelerator' -ForEach $expectedEnumNames {
-            $typeAccelerators.Keys | Should -Contain $_ -Because 'the framework registers public enums as type accelerators'
+            $registered = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')::Get
+            $registered.Keys | Should -Contain $_ -Because 'the framework registers public enums as type accelerators'
         }
 
         It 'Should register public class [<_>] as a type accelerator' -ForEach $expectedClassNames {
-            $typeAccelerators.Keys | Should -Contain $_ -Because 'the framework registers public classes as type accelerators'
+            $registered = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')::Get
+            $registered.Keys | Should -Contain $_ -Because 'the framework registers public classes as type accelerators'
         }
     }
 
     Context 'Framework - Module OnRemove cleanup' -Skip:(-not $hasClassExporter) {
         It 'Should clean up type accelerators when the module is removed' {
             # Capture type names before removal
-            $typeNames = $expectedTypeNames.Clone()
+            $typeNames = @(@($expectedEnumNames) + @($expectedClassNames) | Where-Object { $_ })
             $typeNames | Should -Not -BeNullOrEmpty -Because 'there should be types to verify cleanup for'
 
             # Remove the module to trigger the OnRemove hook

--- a/src/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/src/tests/Module/PSModule/PSModule.Tests.ps1
@@ -12,35 +12,33 @@ param(
     [string] $Path
 )
 
-BeforeAll {
-    $moduleName = Split-Path -Path (Split-Path -Path $Path -Parent) -Leaf
-    $moduleManifestPath = Join-Path -Path $Path -ChildPath "$moduleName.psd1"
-    $moduleRootPath = Join-Path -Path $Path -ChildPath "$moduleName.psm1"
-    Write-Verbose "Module Manifest Path: [$moduleManifestPath]"
-    Write-Verbose "Module Root Path: [$moduleRootPath]"
+# Discovery-phase variables — must be set at script scope (outside BeforeAll) so that
+# Pester's -Skip and -ForEach parameters can reference them during test discovery.
+$moduleName = Split-Path -Path (Split-Path -Path $Path -Parent) -Leaf
+$moduleManifestPath = Join-Path -Path $Path -ChildPath "$moduleName.psd1"
+$moduleRootPath = Join-Path -Path $Path -ChildPath "$moduleName.psm1"
 
-    # Discover public classes and enums from the compiled module source.
-    # The class exporter region is injected by Build-PSModule when classes/public contains types.
-    $moduleContent = if (Test-Path -Path $moduleRootPath) { Get-Content -Path $moduleRootPath -Raw } else { '' }
-    $hasClassExporter = $moduleContent -match '#region\s+Class exporter'
+# Discover public classes and enums from the compiled module source.
+# The class exporter region is injected by Build-PSModule when classes/public contains types.
+$moduleContent = if (Test-Path -Path $moduleRootPath) { Get-Content -Path $moduleRootPath -Raw } else { '' }
+$hasClassExporter = $moduleContent -match '#region\s+Class exporter'
 
-    # Extract expected class and enum names from the class exporter block.
-    $expectedClassNames = @()
-    $expectedEnumNames = @()
-    if ($hasClassExporter) {
-        # Match $ExportableClasses = @( ... ) block
-        if ($moduleContent -match '\$ExportableClasses\s*=\s*@\(([\s\S]*?)\)') {
-            $expectedClassNames = [regex]::Matches($Matches[1], '\[([^\]]+)\]') | ForEach-Object { $_.Groups[1].Value }
-        }
-        # Match $ExportableEnums = @( ... ) block
-        if ($moduleContent -match '\$ExportableEnums\s*=\s*@\(([\s\S]*?)\)') {
-            $expectedEnumNames = [regex]::Matches($Matches[1], '\[([^\]]+)\]') | ForEach-Object { $_.Groups[1].Value }
-        }
+# Extract expected class and enum names from the class exporter block.
+$expectedClassNames = @()
+$expectedEnumNames = @()
+if ($hasClassExporter) {
+    # Match $ExportableClasses = @( ... ) block
+    if ($moduleContent -match '\$ExportableClasses\s*=\s*@\(([\s\S]*?)\)') {
+        $expectedClassNames = @([regex]::Matches($Matches[1], '\[([^\]]+)\]') | ForEach-Object { $_.Groups[1].Value })
     }
-    Write-Host "Has class exporter: $hasClassExporter"
-    Write-Host "Expected classes: $($expectedClassNames -join ', ')"
-    Write-Host "Expected enums: $($expectedEnumNames -join ', ')"
+    # Match $ExportableEnums = @( ... ) block
+    if ($moduleContent -match '\$ExportableEnums\s*=\s*@\(([\s\S]*?)\)') {
+        $expectedEnumNames = @([regex]::Matches($Matches[1], '\[([^\]]+)\]') | ForEach-Object { $_.Groups[1].Value })
+    }
 }
+Write-Host "Has class exporter: $hasClassExporter"
+Write-Host "Expected classes: $($expectedClassNames -join ', ')"
+Write-Host "Expected enums: $($expectedEnumNames -join ', ')"
 
 Describe 'PSModule - Module tests' {
     Context 'Module' {

--- a/src/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/src/tests/Module/PSModule/PSModule.Tests.ps1
@@ -84,22 +84,23 @@ Describe 'PSModule - Module tests' {
         }
     }
 
-    Context 'Framework - Module OnRemove cleanup' {
-        It 'Should remove the module cleanly and re-import without errors' {
-            # Remove the module to trigger the OnRemove hook
-            { Remove-Module -Name $moduleName -Force } | Should -Not -Throw
+    Context 'Framework - Module OnRemove cleanup' -Skip:(-not $hasClassExporter) {
+        It 'Should clean up type accelerators when the module is removed' {
+            # Capture type names before removal
+            $typeNames = @(@($expectedEnumNames) + @($expectedClassNames) | Where-Object { $_ })
+            $typeNames | Should -Not -BeNullOrEmpty -Because 'there should be types to verify cleanup for'
 
-            # Verify type accelerators are cleaned up when class exporter is present
-            if ($hasClassExporter) {
-                $typeNames = @(@($expectedEnumNames) + @($expectedClassNames) | Where-Object { $_ })
-                $typeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')::Get
-                foreach ($typeName in $typeNames) {
-                    $typeAccelerators.Keys | Should -Not -Contain $typeName -Because "the OnRemove hook should remove type accelerator [$typeName]"
-                }
+            # Remove the module to trigger the OnRemove hook
+            Remove-Module -Name $moduleName -Force
+
+            # Verify type accelerators are cleaned up
+            $typeAccelerators = [psobject].Assembly.GetType('System.Management.Automation.TypeAccelerators')::Get
+            foreach ($typeName in $typeNames) {
+                $typeAccelerators.Keys | Should -Not -Contain $typeName -Because "the OnRemove hook should remove type accelerator [$typeName]"
             }
 
             # Re-import the module for any subsequent tests
-            { Import-Module -Name $moduleName -Force } | Should -Not -Throw
+            Import-Module -Name $moduleName -Force
         }
     }
 }

--- a/src/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/src/tests/Module/PSModule/PSModule.Tests.ps1
@@ -41,6 +41,16 @@ Write-Host "Expected classes: $($expectedClassNames -join ', ')"
 Write-Host "Expected enums: $($expectedEnumNames -join ', ')"
 
 Describe 'PSModule - Module tests' {
+    BeforeAll {
+        # Re-expose discovery-phase variables for the Run phase (It blocks).
+        # Pester v5 script-scope variables are visible during Discovery but not inside It blocks.
+        $moduleName = $script:moduleName
+        $moduleManifestPath = $script:moduleManifestPath
+        $hasClassExporter = $script:hasClassExporter
+        $expectedClassNames = $script:expectedClassNames
+        $expectedEnumNames = $script:expectedEnumNames
+    }
+
     Context 'Module' {
         It 'The module should be importable' {
             { Import-Module -Name $moduleManifestPath -Force } | Should -Not -Throw

--- a/src/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/src/tests/Module/PSModule/PSModule.Tests.ps1
@@ -40,12 +40,12 @@ if ($hasClassExporter) {
         $expectedEnumNames = @([regex]::Matches($Matches[1], '\[([^\]]+)\]') | ForEach-Object { $_.Groups[1].Value })
     }
 }
-Write-Host "Has class exporter: $hasClassExporter"
-Write-Host "Expected classes: $($expectedClassNames -join ', ')"
-Write-Host "Expected enums: $($expectedEnumNames -join ', ')"
 
-# Run-phase setup — recompute from $Path (available in both Discovery and Run phases).
-# Script-level variables above only exist during Discovery; BeforeAll runs only during Run.
+
+# Run-phase setup — recompute from $Path so that It/Context blocks can use these variables.
+# Pester v5 Discovery and Run are separate executions. The script-scope variables above drive
+# -Skip and -ForEach during Discovery. This BeforeAll recomputes the same values for the Run
+# phase, where It blocks actually execute. The duplication is intentional and required.
 BeforeAll {
     $moduleName = Split-Path -Path (Split-Path -Path $Path -Parent) -Leaf
     $moduleManifestPath = Join-Path -Path $Path -ChildPath "$moduleName.psd1"
@@ -64,9 +64,9 @@ BeforeAll {
             $expectedEnumNames = @([regex]::Matches($Matches[1], '\[([^\]]+)\]') | ForEach-Object { $_.Groups[1].Value })
         }
     }
-    Write-Host "Run phase - Module: $moduleName"
-    Write-Host "Run phase - Manifest: $moduleManifestPath"
-    Write-Host "Run phase - Has class exporter: $hasClassExporter"
+    Write-Host "Has class exporter: $hasClassExporter"
+    Write-Host "Expected classes: $($expectedClassNames -join ', ')"
+    Write-Host "Expected enums: $($expectedEnumNames -join ', ')"
 }
 
 Describe 'PSModule - Module tests' {

--- a/src/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/src/tests/Module/PSModule/PSModule.Tests.ps1
@@ -89,20 +89,6 @@ Describe 'PSModule - Module tests' {
         }
     }
 
-    Context 'Framework - IsWindows compatibility shim' {
-        BeforeAll {
-            Import-Module -Name $moduleManifestPath -Force
-            $script:moduleRef = Get-Module -Name $moduleName
-        }
-        It 'Should have $IsWindows defined in the module scope' {
-            # The framework injects "$IsWindows = $true" for PowerShell 5.1 (Desktop edition).
-            # On PS 7+ (Core), $IsWindows is a built-in automatic variable.
-            # The variable is set inside the module scope and is not exported, so we must check from within the module.
-            $isWindowsDefined = & $script:moduleRef { Get-Variable -Name 'IsWindows' -ErrorAction SilentlyContinue }
-            $isWindowsDefined | Should -Not -BeNullOrEmpty -Because 'the framework injects a compatibility shim for PS 5.1'
-        }
-    }
-
     Context 'Framework - Type accelerator registration' -Skip:(-not $hasClassExporter) {
         BeforeAll {
             Import-Module -Name $moduleManifestPath -Force

--- a/src/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/src/tests/Module/PSModule/PSModule.Tests.ps1
@@ -40,17 +40,32 @@ Write-Host "Has class exporter: $hasClassExporter"
 Write-Host "Expected classes: $($expectedClassNames -join ', ')"
 Write-Host "Expected enums: $($expectedEnumNames -join ', ')"
 
-Describe 'PSModule - Module tests' {
-    BeforeAll {
-        # Re-expose discovery-phase variables for the Run phase (It blocks).
-        # Pester v5 script-scope variables are visible during Discovery but not inside It blocks.
-        $moduleName = $script:moduleName
-        $moduleManifestPath = $script:moduleManifestPath
-        $hasClassExporter = $script:hasClassExporter
-        $expectedClassNames = $script:expectedClassNames
-        $expectedEnumNames = $script:expectedEnumNames
-    }
+# Run-phase setup — recompute from $Path (available in both Discovery and Run phases).
+# Script-level variables above only exist during Discovery; BeforeAll runs only during Run.
+BeforeAll {
+    $moduleName = Split-Path -Path (Split-Path -Path $Path -Parent) -Leaf
+    $moduleManifestPath = Join-Path -Path $Path -ChildPath "$moduleName.psd1"
+    $moduleRootPath = Join-Path -Path $Path -ChildPath "$moduleName.psm1"
 
+    $moduleContent = if (Test-Path -Path $moduleRootPath) { Get-Content -Path $moduleRootPath -Raw } else { '' }
+    $hasClassExporter = $moduleContent -match '#region\s+Class exporter'
+
+    $expectedClassNames = @()
+    $expectedEnumNames = @()
+    if ($hasClassExporter) {
+        if ($moduleContent -match '\$ExportableClasses\s*=\s*@\(([\s\S]*?)\)') {
+            $expectedClassNames = @([regex]::Matches($Matches[1], '\[([^\]]+)\]') | ForEach-Object { $_.Groups[1].Value })
+        }
+        if ($moduleContent -match '\$ExportableEnums\s*=\s*@\(([\s\S]*?)\)') {
+            $expectedEnumNames = @([regex]::Matches($Matches[1], '\[([^\]]+)\]') | ForEach-Object { $_.Groups[1].Value })
+        }
+    }
+    Write-Host "Run phase - Module: $moduleName"
+    Write-Host "Run phase - Manifest: $moduleManifestPath"
+    Write-Host "Run phase - Has class exporter: $hasClassExporter"
+}
+
+Describe 'PSModule - Module tests' {
     Context 'Module' {
         It 'The module should be importable' {
             { Import-Module -Name $moduleManifestPath -Force } | Should -Not -Throw

--- a/src/tests/Module/PSModule/PSModule.Tests.ps1
+++ b/src/tests/Module/PSModule/PSModule.Tests.ps1
@@ -6,6 +6,10 @@
     'PSAvoidUsingWriteHost', '',
     Justification = 'Log outputs to GitHub Actions logs.'
 )]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', '',
+    Justification = 'Variables are set in BeforeAll and consumed in Describe/It blocks.'
+)]
 [CmdLetBinding()]
 param(
     [Parameter(Mandatory)]

--- a/tests/outputTestRepo/outputs/module/PSModuleTest/PSModuleTest.psm1
+++ b/tests/outputTestRepo/outputs/module/PSModuleTest/PSModuleTest.psm1
@@ -1,9 +1,23 @@
 ﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Contains long links.')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSAvoidAssignmentToAutomaticVariable', 'IsWindows',
+    Justification = 'IsWindows does not exist in PS5.1'
+)]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+    'PSUseDeclaredVarsMoreThanAssignments', 'IsWindows',
+    Justification = 'IsWindows does not exist in PS5.1'
+)]
 [CmdletBinding()]
 param()
 
 $scriptName = $MyInvocation.MyCommand.Name
 Write-Debug "[$scriptName] Importing module"
+
+#region - IsWindows compatibility shim
+if ($PSEdition -eq 'Desktop') {
+    $IsWindows = $true
+}
+#endregion - IsWindows compatibility shim
 
 #region - Data import
 Write-Debug "[$scriptName] - [data] - Processing folder"
@@ -376,6 +390,48 @@ Write-Verbose '---  THIS IS A LAST LOADER ---'
 Write-Verbose '------------------------------'
 Write-Debug "[$scriptName] - [/finally.ps1] - Done"
 #endregion - From /finally.ps1
+
+#region    Class exporter
+# Get the internal TypeAccelerators class to use its static methods.
+$TypeAcceleratorsClass = [psobject].Assembly.GetType(
+    'System.Management.Automation.TypeAccelerators'
+)
+# Ensure none of the types would clobber an existing type accelerator.
+# If a type accelerator with the same name exists, throw an exception.
+$ExistingTypeAccelerators = $TypeAcceleratorsClass::Get
+# Define the types to export with type accelerators.
+$ExportableEnums = @(
+)
+$ExportableEnums | Foreach-Object { Write-Verbose "Exporting enum '$($_.FullName)'." }
+foreach ($Type in $ExportableEnums) {
+    if ($Type.FullName -in $ExistingTypeAccelerators.Keys) {
+        Write-Verbose "Enum already exists [$($Type.FullName)]. Skipping."
+    } else {
+        Write-Verbose "Importing enum '$Type'."
+        $TypeAcceleratorsClass::Add($Type.FullName, $Type)
+    }
+}
+$ExportableClasses = @(
+    [Book]
+    [BookList]
+)
+$ExportableClasses | Foreach-Object { Write-Verbose "Exporting class '$($_.FullName)'." }
+foreach ($Type in $ExportableClasses) {
+    if ($Type.FullName -in $ExistingTypeAccelerators.Keys) {
+        Write-Verbose "Class already exists [$($Type.FullName)]. Skipping."
+    } else {
+        Write-Verbose "Importing class '$Type'."
+        $TypeAcceleratorsClass::Add($Type.FullName, $Type)
+    }
+}
+
+# Remove type accelerators when the module is removed.
+$MyInvocation.MyCommand.ScriptBlock.Module.OnRemove = {
+    foreach ($Type in ($ExportableEnums + $ExportableClasses)) {
+        $null = $TypeAcceleratorsClass::Remove($Type.FullName)
+    }
+}.GetNewClosure()
+#endregion Class exporter
 
 $exports = @{
     Cmdlet   = ''

--- a/tests/outputTestRepo/outputs/module/PSModuleTest/PSModuleTest.psm1
+++ b/tests/outputTestRepo/outputs/module/PSModuleTest/PSModuleTest.psm1
@@ -204,7 +204,7 @@ Write-Debug "[$scriptName] - [/private] - Processing folder"
 #region - From /private/Get-InternalPSModule.ps1
 Write-Debug "[$scriptName] - [/private/Get-InternalPSModule.ps1] - Importing"
 
-Function Get-InternalPSModule {
+function Get-InternalPSModule {
     <#
         .SYNOPSIS
         Performs tests on a module.
@@ -228,7 +228,7 @@ Write-Debug "[$scriptName] - [/private/Get-InternalPSModule.ps1] - Done"
 #region - From /private/Set-InternalPSModule.ps1
 Write-Debug "[$scriptName] - [/private/Set-InternalPSModule.ps1] - Importing"
 
-Function Set-InternalPSModule {
+function Set-InternalPSModule {
     <#
         .SYNOPSIS
         Performs tests on a module.
@@ -402,7 +402,7 @@ $ExistingTypeAccelerators = $TypeAcceleratorsClass::Get
 # Define the types to export with type accelerators.
 $ExportableEnums = @(
 )
-$ExportableEnums | Foreach-Object { Write-Verbose "Exporting enum '$($_.FullName)'." }
+$ExportableEnums | ForEach-Object { Write-Verbose "Exporting enum '$($_.FullName)'." }
 foreach ($Type in $ExportableEnums) {
     if ($Type.FullName -in $ExistingTypeAccelerators.Keys) {
         Write-Verbose "Enum already exists [$($Type.FullName)]. Skipping."
@@ -415,7 +415,7 @@ $ExportableClasses = @(
     [Book]
     [BookList]
 )
-$ExportableClasses | Foreach-Object { Write-Verbose "Exporting class '$($_.FullName)'." }
+$ExportableClasses | ForEach-Object { Write-Verbose "Exporting class '$($_.FullName)'." }
 foreach ($Type in $ExportableClasses) {
     if ($Type.FullName -in $ExistingTypeAccelerators.Keys) {
         Write-Verbose "Class already exists [$($Type.FullName)]. Skipping."

--- a/tests/outputTestRepo/outputs/module/PSModuleTest/PSModuleTest.psm1
+++ b/tests/outputTestRepo/outputs/module/PSModuleTest/PSModuleTest.psm1
@@ -383,7 +383,7 @@ $TypeAcceleratorsClass = [psobject].Assembly.GetType(
     'System.Management.Automation.TypeAccelerators'
 )
 # Ensure none of the types would clobber an existing type accelerator.
-# If a type accelerator with the same name exists, throw an exception.
+# If a type accelerator with the same name already exists, skip adding it.
 $ExistingTypeAccelerators = $TypeAcceleratorsClass::Get
 # Define the types to export with type accelerators.
 $ExportableEnums = @(

--- a/tests/outputTestRepo/outputs/module/PSModuleTest/PSModuleTest.psm1
+++ b/tests/outputTestRepo/outputs/module/PSModuleTest/PSModuleTest.psm1
@@ -1,23 +1,9 @@
 ﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidLongLines', '', Justification = 'Contains long links.')]
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
-    'PSAvoidAssignmentToAutomaticVariable', 'IsWindows',
-    Justification = 'IsWindows does not exist in PS5.1'
-)]
-[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
-    'PSUseDeclaredVarsMoreThanAssignments', 'IsWindows',
-    Justification = 'IsWindows does not exist in PS5.1'
-)]
 [CmdletBinding()]
 param()
 
 $scriptName = $MyInvocation.MyCommand.Name
 Write-Debug "[$scriptName] Importing module"
-
-#region - IsWindows compatibility shim
-if ($PSEdition -eq 'Desktop') {
-    $IsWindows = $true
-}
-#endregion - IsWindows compatibility shim
 
 #region - Data import
 Write-Debug "[$scriptName] - [data] - Processing folder"


### PR DESCRIPTION
Module tests now validate framework-injected boilerplate — type accelerator registration and OnRemove cleanup — so code coverage reflects actual test gaps instead of penalizing module authors for untested framework code.

## New: Type accelerator registration tests

When `Build-PSModule` injects a class exporter region, the module tests now verify that every public class and enum listed in `$ExportableClasses` / `$ExportableEnums` is registered as a type accelerator after import.

```
Context Framework - Type accelerator registration
  [+] Should register public class [Book] as a type accelerator
  [+] Should register public class [BookList] as a type accelerator
```

Modules without a class exporter region skip these tests automatically.

## New: OnRemove cleanup tests

A new test verifies that when the module is removed, its type accelerators are cleaned up via the `OnRemove` hook — preventing type collisions when re-importing or importing a different version.

```
Context Framework - Module OnRemove cleanup
  [+] Should clean up type accelerators when the module is removed
```

## Changed: IsWindows compatibility shim removed

The `$IsWindows = $true` PS 5.1 Desktop edition shim has been removed from `Build-PSModule` (see [PSModule/Build-PSModule#132](https://github.com/PSModule/Build-PSModule/pull/132)). The corresponding test context and test fixture output have been removed here as well. PSModule targets PowerShell LTS (7.6+) where `$IsWindows` is a built-in automatic variable.

## Technical Details

- `PSModule.Tests.ps1`: Discovery-phase variables (`$hasClassExporter`, `$expectedClassNames`, `$expectedEnumNames`) are computed at script scope for Pester's `-Skip`/`-ForEach` evaluation, then recomputed in a top-level `BeforeAll` for the Run phase. This dual-computation pattern is required because Pester v5 Discovery and Run are separate executions that don't share script-scope state.
- `PSModuleTest.psm1` (test fixture): Updated to remove the `$IsWindows` shim and its suppression attributes, matching the new Build-PSModule output format.
- PSScriptAnalyzer `PSUseDeclaredVarsMoreThanAssignments` suppressed at file level because the analyzer cannot trace variable flow across Pester's `BeforeAll` → `It` block boundaries.